### PR TITLE
Updates for terraform 7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,19 @@
 PATH
   remote: .
   specs:
-    terrafying (0.1.0)
+    terrafying (0.2.1)
       aws-sdk (~> 2)
       thor (~> 0.19.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (2.4.0)
-      aws-sdk-resources (= 2.4.0)
-    aws-sdk-core (2.4.0)
+    aws-sdk (2.5.7)
+      aws-sdk-resources (= 2.5.7)
+    aws-sdk-core (2.5.7)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.4.0)
-      aws-sdk-core (= 2.4.0)
+    aws-sdk-resources (2.5.7)
+      aws-sdk-core (= 2.5.7)
     jmespath (1.3.1)
     rake (10.5.0)
     thor (0.19.1)
@@ -27,4 +27,4 @@ DEPENDENCIES
   terrafying!
 
 BUNDLED WITH
-   1.12.3
+   1.12.5

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A small ruby dsl for [terraform](https://www.terraform.io), based on [terrafied]
 ## Setup
 
 - Ruby 2.2:ish
-- Terraform >=0.7.0: https://www.terraform.io/downloads.html
+- Terraform >= 0.7.1: https://www.terraform.io/downloads.html
   - OSX: `brew install terraform`
 - `bundle install`
 

--- a/lib/terrafying/generator.rb
+++ b/lib/terrafying/generator.rb
@@ -70,6 +70,17 @@ module Terrafying
       aws_nat_gateway
       aws_eip
       aws_elb
+      aws_elb_service_account
+      aws_alb
+      aws_alb_listener
+      aws_alb_target_group
+      aws_alb_target_group_attachment
+      aws_alb_target_group_rule
+      aws_load_balancer_policy
+      aws_load_balancer_backend_server_policy
+      aws_load_balancer_listener_policy
+      aws_vpn_gateway_attachment
+      aws_lb_ssl_negotiation_policy
       aws_s3_bucket
       aws_security_group
       aws_security_group_rule

--- a/lib/terrafying/version.rb
+++ b/lib/terrafying/version.rb
@@ -1,3 +1,3 @@
 module Terrafying
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
This includes application load balancer (alb's).
Should be backwards compatible, and you only need to upgrade terraform if you're using the new ALB stuff.