### PR TITLE
Dynamically call the resource function instead of hardcoded whitelist

### DIFF
--- a/lib/terrafying/generator.rb
+++ b/lib/terrafying/generator.rb
@@ -46,68 +46,8 @@ module Terrafying
       "${#{type}.#{name}.#{value}}"
     end
 
-    %w[aws_vpc
-      aws_rds_cluster
-      aws_route
-      aws_route_table
-      aws_route_table_association
-      aws_main_route_table_association
-      aws_subnet
-      aws_autoscaling_group
-      aws_launch_configuration
-      aws_ecs_cluster
-      aws_ecs_task_definition
-      aws_ecs_service
-      aws_cloudwatch_log_group
-      aws_cloudwatch_metric_alarm
-      aws_route53_record
-      aws_route53_zone
-      aws_internet_gateway
-      aws_ebs_volume
-      aws_instance
-      aws_iam_access_key
-      aws_iam_instance_profile
-      aws_iam_role
-      aws_iam_role_policy
-      aws_iam_user
-      aws_iam_user_policy
-      aws_nat_gateway
-      aws_eip
-      aws_elb
-      aws_elb_service_account
-      aws_alb
-      aws_alb_listener
-      aws_alb_target_group
-      aws_alb_target_group_attachment
-      aws_alb_target_group_rule
-      aws_load_balancer_policy
-      aws_load_balancer_backend_server_policy
-      aws_load_balancer_listener_policy
-      aws_vpn_gateway_attachment
-      aws_lb_ssl_negotiation_policy
-      aws_s3_bucket
-      aws_security_group
-      aws_security_group_rule
-      aws_elasticsearch_domain
-      aws_volume_attachment
-      aws_db_instance
-      aws_db_subnet_group
-      aws_dynamodb_table
-      aws_kinesis_firehose_delivery_stream
-      aws_kinesis_stream
-      aws_sqs_queue
-      aws_elasticache_cluster
-      github_team
-      github_team_membership
-      github_team_repository
-      aws_vpn_gateway
-      aws_sqs_queue
-      aws_cloudwatch_log_subscription_filter
-      aws_proxy_protocol_policy
-    ].each do |type|
-      define_singleton_method type do |name, attributes={}|
-        resource(type, name, attributes)
-      end
+    def self.method_missing(fn, *args)
+      resource(fn, args.shift.to_s, args.first)
     end
 
     def self.pretty_generate


### PR DESCRIPTION
Attempt to get rid of a hardcoded whitelist of resource types; unfortunately a few helper functions seem to trigger method_missing, so I had to exclude them - ending up with a different kind of whitelist... Any better way of doing this?