### PR TITLE
Stop patching DSL onto main

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A small ruby dsl for [terraform](https://www.terraform.io), based on [terrafied]
 The `terrafying` command is in `bin`:
 
 ```
-$ ./bin/terrafying 
+$ ./bin/terrafying
 Commands:
   terrafying apply PATH             # Apply changes to resources
   terrafying destroy PATH           # Destroy resources
@@ -39,16 +39,18 @@ Create ruby file somewhere and declare resources as you wish.
 For example `example/main.rb`
 
 ```ruby
-aws_security_group "example_group", {
-  name: "example_group",
-  description: "Allow all inbound traffic to port 80",
-  vpc_id: 'vpc-ec0c118e',
+Terrafying::Generator.generate {
+  aws_security_group "example_group", {
+    name: "example_group",
+    description: "Allow all inbound traffic to port 80",
+    vpc_id: 'vpc-ec0c118e',
 
-  ingress: {
-    from_port: 80,
-    to_port: 80,
-    protocol: "tcp",
-    cidr_blocks: ["0.0.0.0/0"],
+    ingress: {
+      from_port: 80,
+      to_port: 80,
+      protocol: "tcp",
+      cidr_blocks: ["0.0.0.0/0"],
+    }
   }
 }
 ```
@@ -58,7 +60,7 @@ aws_security_group "example_group", {
 Run `./bin/terrafying plan example/main.rb`:
 
 ```
-$ ./bin/terrafying plan example/main.rb 
+$ ./bin/terrafying plan example/main.rb
 Refreshing Terraform state prior to plan...
 
 
@@ -96,7 +98,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 Run `./bin/terrafying apply`
 
 ```
-$ ./bin/terrafying apply example/main.rb 
+$ ./bin/terrafying apply example/main.rb
 aws_security_group.example_group: Creating...
   description:                          "" => "Allow all inbound traffic to port 80"
   egress.#:                             "" => "<computed>"
@@ -139,5 +141,3 @@ If you or someone else has a lock that you want to re-acquire or steal
 ```
 $ ./bin/terrafying apply -f example/main.rb
 ```
-
-

--- a/lib/terrafying.rb
+++ b/lib/terrafying.rb
@@ -13,8 +13,6 @@ require 'terrafying/lock'
 require 'terrafying/version'
 require 'terrafying/state'
 
-include Terrafying::Generator
-
 module Terrafying
 
   class Config
@@ -47,7 +45,7 @@ module Terrafying
         end
       end
     end
-    
+
     def apply
       with_config do
         with_lock do
@@ -75,7 +73,7 @@ module Terrafying
     def show_state
       puts(State.store(self).get)
     end
-    
+
     def use_remote_state
       with_lock do
         local = State.local(self)
@@ -96,10 +94,10 @@ module Terrafying
         end
       end
     end
-    
+
 
     private
-   
+
     def with_config(&block)
       name = File.basename(@path, ".*")
       dir = File.join(git_toplevel, 'tmp', SecureRandom.uuid)
@@ -110,7 +108,7 @@ module Terrafying
           File.write(output, Terrafying::Generator.pretty_generate)
           yield block
         ensure
-          FileUtils.rm_rf(dir) unless @options[:keep] 
+          FileUtils.rm_rf(dir) unless @options[:keep]
         end
       end
     end
@@ -149,23 +147,23 @@ module Terrafying
       rescue => e
         raise "Error retrieving state for config #{self}: #{e}"
       end
-      
+
       yield block
 
       begin
-        if opts[:mode] == :update 
+        if opts[:mode] == :update
           store.put(IO.read(State::STATE_FILENAME))
         end
       rescue => e
         raise "Error updating state for config #{self}: #{e}"
-      end      
+      end
     end
-    
+
     def scope_for_path(path)
       top_level_path = Pathname.new(git_toplevel)
       Pathname.new(@path).relative_path_from(top_level_path).to_s
     end
-    
+
     def git_toplevel
       @top_level ||= begin
                        top_level = `git rev-parse --show-toplevel`
@@ -173,6 +171,6 @@ module Terrafying
                        File.expand_path(top_level.chomp)
                      end
     end
-    
+
   end
 end

--- a/lib/terrafying/version.rb
+++ b/lib/terrafying/version.rb
@@ -1,3 +1,3 @@
 module Terrafying
-  VERSION = "0.2.1"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
This requires all DSL generation to be wrapped in a block passed to `Terrafying::Generator.generate`

This is a major breaking change, but upgrading is very simple.

This means this gem can be used more more safely with other ruby code.

Fixes #6.