### PR TITLE
Check for terraform existence + version

### DIFF
--- a/lib/terrafying.rb
+++ b/lib/terrafying.rb
@@ -99,7 +99,7 @@ module Terrafying
     private
 
     def with_config(&block)
-      abort("ERROR: You must have terraform installed to run this gem") unless terraform_installed?
+      abort("***** ERROR: You must have terraform installed to run this gem *****") unless terraform_installed?
       check_version
       name = File.basename(@path, ".*")
       dir = File.join(git_toplevel, 'tmp', SecureRandom.uuid)
@@ -175,13 +175,17 @@ module Terrafying
     end
 
     def check_version
-      if (`terraform -v` =~ /#{Terrafying::CLI_VERSION}/) == nil
-        abort("ERROR: You must have #{Terrafying::CLI_VERSION} of Terraform installed to run any command")
+      if terraform_version != Terrafying::CLI_VERSION
+        abort("***** ERROR: You must have v#{Terrafying::CLI_VERSION} of terraform installed to run any command (you are running v#{terraform_version}) *****")
       end
     end
 
     def terraform_installed?
       which('terraform')
+    end
+
+    def terraform_version
+      `terraform -v`.split("v").last.delete!("\n")
     end
 
     # Cross-platform way of finding an executable in the $PATH.

--- a/lib/terrafying.rb
+++ b/lib/terrafying.rb
@@ -99,6 +99,8 @@ module Terrafying
     private
 
     def with_config(&block)
+      abort("ERROR: You must have terraform installed to run this gem") unless terraform_installed?
+      check_version
       name = File.basename(@path, ".*")
       dir = File.join(git_toplevel, 'tmp', SecureRandom.uuid)
       FileUtils.mkdir_p dir
@@ -172,5 +174,28 @@ module Terrafying
                      end
     end
 
+    def check_version
+      if (`terraform -v` =~ /#{Terrafying::CLI_VERSION}/) == nil
+        abort("ERROR: You must have #{Terrafying::CLI_VERSION} of Terraform installed to run any command")
+      end
+    end
+
+    def terraform_installed?
+      which('terraform')
+    end
+
+    # Cross-platform way of finding an executable in the $PATH.
+    #
+    #   which('ruby') #=> /usr/bin/ruby
+    def which(cmd)
+      exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+      ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
+        exts.each { |ext|
+          exe = File.join(path, "#{cmd}#{ext}")
+          return exe if File.executable?(exe) && !File.directory?(exe)
+        }
+      end
+      return nil
+    end
   end
 end

--- a/lib/terrafying/version.rb
+++ b/lib/terrafying/version.rb
@@ -1,3 +1,4 @@
 module Terrafying
   VERSION = "1.0.0"
+  CLI_VERSION = "0.8.0"
 end


### PR DESCRIPTION
Problem 
===

1. Terrafying doesn't check for terraform as a requirement, which means when you try and `plan` or `apply` it outputs nothing to tell the user they haven't installed terraform
2. As terraform is still in baby stages, it's being under active development which means new versions keep cropping up - this poses a problem when users have an older version than the one someone else used on the same spec. Terraform will error and not let you continue.

Solution
===

- Checks for terraform in your path before you can execute any configuration
- `Terrafying::CLI_VERSION` has now been set at `0.8.0` and any person trying to use an older version or newer version of terraform will get an error message instructing them to use the CLI defined version in the gem. 

Potential issues
===

As terraform is being upgraded all the time, the `CLI_VERSION` might need to be constantly updated to keep in line with new changes/bug fixes. We could make sure that the version is the MINIMAL version, but due to breaking changes in terraform this might not be a good idea.