### PR TITLE
Upgrades the terraform version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ A small ruby dsl for [terraform](https://www.terraform.io), based on [terrafied]
 ## Setup
 
 - Ruby 2.2:ish
-- Terraform = 0.8.0: https://www.terraform.io/downloads.html
+- Terraform with the right version: https://www.terraform.io/downloads.html
   - OSX: `brew install terraform`
 - `bundle install`
 
 ###
 
-`Terraform::CLI_VERSION` checks for the correct version of terraform. Due to Hashicorp continually releasing versions and sometimes with breaking changes / bugs, we have locked the terraform version of this DSL to `0.8.0`. As terraform continues to get updated we will attempt to keep this version up-to-date with the latest stable version of terraform.
+`Terraform::CLI_VERSION` checks for the correct version of terraform. Due to Hashicorp continually releasing versions and sometimes with breaking changes / bugs, we have locked the terraform version. As terraform continues to get updated we will attempt to keep this version up-to-date with the latest stable version of terraform.
 
 ## Usage
 

--- a/lib/terrafying/version.rb
+++ b/lib/terrafying/version.rb
@@ -1,4 +1,4 @@
 module Terrafying
   VERSION = "1.0.3"
-  CLI_VERSION = "0.8.4"
+  CLI_VERSION = "0.8.5"
 end


### PR DESCRIPTION
0.8.5 (26 January 2017)
BACKWARDS INCOMPATIBILITIES / NOTES:
provider/aws: We no longer prefix an ECR repository address with https://
provider/google: google_project has undergone significant changes. Existing configs and state should continue to work as they always have, but new configs and state will exhibit some new behaviour, including actually creating and deleting projects, instead of just referencing them. See https://www.terraform.io/docs/providers/google/r/google_project.html for more details.

see https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md for more info.