### PR TITLE
Make json diffs readable, to avoid 'Looks right' on policies

### DIFF
--- a/lib/terrafying.rb
+++ b/lib/terrafying.rb
@@ -98,11 +98,12 @@ module Terrafying
     private
 
     def exec_with_optional_target(command)
-      if @options[:target]
-        system("terraform #{command} -target=#{@options[:target]}")
+      output = if @options[:target]
+        `terraform #{command} -target=#{@options[:target]}`
       else
-        system("terraform #{command}")
+        `terraform #{command}`
       end
+      puts output.gsub('\n', "\n").gsub('\\"', "\"")
     end
 
     def with_config(&block)


### PR DESCRIPTION
This moves from things like:

```
~ aws_iam_role_policy.broadband_sales_dynamodb_policy
    policy: "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"dynamodb:*\"\n            ],\n            \"Resource\": [\n                \"arn:aws:dynamodb:eu-west-1:136393635417:table/broadband_sales_approval_rates\",\n                \"arn:aws:dynamodb:eu-west-1:136393635417:table/broadband_sales_approval_rates/index/date-index\",\n                \"arn:aws:dynamodb:eu-west-1:136393635417:table/broadband-tracking-dev\",\n                \"arn:aws:dynamodb:eu-west-1:136393635417:table/broadband-tracking-production\"\n            ]\n        }\n    ]\n}" => "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Action\": [\"dynamodb:*\"],\n      \"Resource\": [\n        \"arn:aws:dynamodb:eu-west-1:136393635417:table/broadband_sales_approval_rates\",\n        \"arn:aws:dynamodb:eu-west-1:136393635417:table/broadband_sales_approval_rates/index/date-index\"\n      ]\n    }\n  ]\n}\n"
```

To things like:

```
~ aws_iam_role_policy.broadband_sales_dynamodb_policy
    policy: "{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "dynamodb:*"
            ],
            "Resource": [
                "arn:aws:dynamodb:eu-west-1:136393635417:table/broadband_sales_approval_rates",
                "arn:aws:dynamodb:eu-west-1:136393635417:table/broadband_sales_approval_rates/index/date-index",
                "arn:aws:dynamodb:eu-west-1:136393635417:table/broadband-tracking-dev",
                "arn:aws:dynamodb:eu-west-1:136393635417:table/broadband-tracking-production"
            ]
        }
    ]
}" => "{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": ["dynamodb:*"],
      "Resource": [
        "arn:aws:dynamodb:eu-west-1:136393635417:table/broadband_sales_approval_rates",
        "arn:aws:dynamodb:eu-west-1:136393635417:table/broadband_sales_approval_rates/index/date-index"
      ]
    }
  ]
}
"
```