### PR TITLE
Do not exit when Terraform fails

### DIFF
--- a/lib/terrafying.rb
+++ b/lib/terrafying.rb
@@ -226,7 +226,6 @@ module Terrafying
       end
       unless $? == 0
         STDERR.puts "***** ERROR: Unable to execute terraform command *****"
-        exit($?)
       end
     end
 


### PR DESCRIPTION
## What

I happened to me multiple times that terraform failed and terrafying left empty state in DynamoDB.
This line causes entire process to exit and do not save Terraform state.