### PR TITLE
Don't generate device name

### DIFF
--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -288,8 +288,6 @@ module Terrafying
                                      }.merge(options[:tags]),
                                    }
 
-              volume[:device] = "/dev/#{Digest::SHA256.hexdigest(volume[:mount])[0..8]}"
-
               resource :aws_volume_attachment, volume_name, {
                          device_name: volume[:device],
                          volume_id: volume_id,


### PR DESCRIPTION
Device name must be in form of: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html
We now require user to provide device name