### PR TITLE
Find zone by tag

### DIFF
--- a/lib/terrafying/components/vpc.rb
+++ b/lib/terrafying/components/vpc.rb
@@ -37,7 +37,10 @@ module Terrafying
         @name = name
         @id = vpc.vpc_id
         @cidr = vpc.cidr_block
-        @zone = "find vpc dns zone by the tag"
+        @zone = Terrafying::Components::Zone.find_by_tag({vpc: @id})
+        if @zone
+          raise "Failed to find zone"
+        end
         @public_subnets = subnets.select { |s| s.public }
         @private_subnets = subnets.select { |s| !s.public }
         tags = vpc.tags.select { |tag| tag.key = "ssh_group"}

--- a/lib/terrafying/components/vpc.rb
+++ b/lib/terrafying/components/vpc.rb
@@ -79,16 +79,16 @@ module Terrafying
         @remaining_ip_space = NetAddr::Tree.new
         @remaining_ip_space.add! cidr
 
-        @zone = add! Terrafying::Components::Zone.create("#{name}.#{parent_zone.fqdn}", {
-                                                           parent_zone: parent_zone,
-                                                           tags: { vpc: @id }.merge(@tags),
-                                                         })
-
         @id = resource :aws_vpc, name, {
                          cidr_block: cidr.to_s,
                          enable_dns_hostnames: true,
                          tags: { Name: name, ssh_group: @ssh_group }.merge(@tags),
                        }
+
+        @zone = add! Terrafying::Components::Zone.create("#{name}.#{parent_zone.fqdn}", {
+                                                           parent_zone: parent_zone,
+                                                           tags: { vpc: @id }.merge(@tags),
+                                                         })
 
         dhcp = resource :aws_vpc_dhcp_options, name, {
                           domain_name: @zone.fqdn,

--- a/lib/terrafying/components/zone.rb
+++ b/lib/terrafying/components/zone.rb
@@ -1,5 +1,3 @@
-
-
 require 'terrafying/generator'
 
 module Terrafying
@@ -12,6 +10,10 @@ module Terrafying
 
       def self.find(fqdn)
         Zone.new.find fqdn
+      end
+
+      def self.find_by_tag(tag)
+        Zone.new.find_by_tag tag
       end
 
       def self.create(fqdn, options={})
@@ -28,6 +30,14 @@ module Terrafying
 
         @id = zone.id
         @fqdn = fqdn
+
+        self
+      end
+
+      def find_by_tag(tag)
+        zone = aws.hosted_zone_by_tag(tag)
+        @id = zone.id
+        @fqdn = zone.name
 
         self
       end


### PR DESCRIPTION
This PR implements `find_by_tag` method for `Zone` component. It will allow us to use `vpc.find`output to `vpn.create` method.

Also this fixed an order of vpc resource creation so now `@id` is created ahead of tag that needs it's value.  