### PR TITLE
Export ssh group

### DIFF
--- a/lib/terrafying/components/vpc.rb
+++ b/lib/terrafying/components/vpc.rb
@@ -38,7 +38,7 @@ module Terrafying
         @id = vpc.vpc_id
         @cidr = vpc.cidr_block
         @zone = Terrafying::Components::Zone.find_by_tag({vpc: @id})
-        if @zone
+        if @zone.nil?
           raise "Failed to find zone"
         end
         @public_subnets = subnets.select { |s| s.public }

--- a/lib/terrafying/components/vpc.rb
+++ b/lib/terrafying/components/vpc.rb
@@ -49,6 +49,7 @@ module Terrafying
         else
           @ssh_group = DEFAULT_SSH_GROUP
         end
+        @internal_ssh_security_group = aws.security_group("#{name}-internal-ssh")
         self
       end
 


### PR DESCRIPTION
The group attribute was not exported but it is used here: https://github.com/uswitch/terrafying/blob/master/lib/terrafying/components/service.rb#L214 making it null and thus failing in terraform:
```
Error: Failed to load root config module: Error parsing /Users/piotrkomborski/dev/src/github.com/uswitch/terrafying-audit/tmp/2e2cd1a5-4ce6-48e5-
ac37-9ef1bbaa87d5/vpn.tf.json: unexpected token while parsing list: NULL
```
