### PR TITLE
Add WantedBy target to mount units for coreos to load on boot

### DIFF
--- a/lib/terrafying/components/templates/service.yaml
+++ b/lib/terrafying/components/templates/service.yaml
@@ -17,6 +17,12 @@ systemd:
     - name: "<%= volume[:mount].tr('/','-')[1..-1] %>.mount"
       enabled: true
       contents: |
+        [Install]
+        WantedBy=local-fs.target
+
+        [Unit]
+        Before=docker.service
+
         [Mount]
         What=<%= volume[:device] %>
         Where=<%= volume[:mount] %>

--- a/spec/terrafying/components/service_spec.rb
+++ b/spec/terrafying/components/service_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Terrafying::Components::Service, '#user_data' do
         unit == {
           name: 'var-test.mount',
           enabled: true,
-          contents: "[Mount]\nWhat=/dev/test\nWhere=/var/test\nType=ext4\n"
+          contents: "[Install]\nWantedBy=local-fs.target\n\n[Unit]\nBefore=docker.service\n\n[Mount]\nWhat=/dev/test\nWhere=/var/test\nType=ext4\n"
         }
       end).to be true
     end


### PR DESCRIPTION
Systemd units will not be loaded without a WantedBy target. This will ensure ensure that volumes are mounted before the docker services as well.