### PR TITLE
More greatness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,11 @@ RUN curl -L -o terraform.zip https://releases.hashicorp.com/terraform/0.11.1/ter
     unzip terraform.zip && rm terraform.zip && \
     mv terraform /usr/bin/terraform
 
+RUN curl -L -o terraform-provider-acme.zip https://github.com/paybyphone/terraform-provider-acme/releases/download/v0.4.0/terraform-provider-acme_v0.4.0_linux_amd64.zip && \
+    unzip terraform-provider-acme.zip && rm terraform-provider-acme.zip && \
+    mkdir -p /root/.terraform.d/plugins/linux_amd64 && \
+    mv terraform-provider-acme /root/.terraform.d/plugins/linux_amd64/terraform-provider-acme_0.4.0
+
 COPY . /usr/src/app
 WORKDIR /usr/src/app
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ DEPENDENCIES
   bundler (~> 1.11)
   rake (~> 10.0)
   rspec (~> 3.7)
+  rspec-mocks (~> 3.7)
   terrafying!
 
 BUNDLED WITH

--- a/lib/terrafying/components.rb
+++ b/lib/terrafying/components.rb
@@ -1,5 +1,6 @@
 
 require 'terrafying/components/ca'
+require 'terrafying/components/letsencrypt'
 require 'terrafying/components/service'
 require 'terrafying/components/subnet'
 require 'terrafying/components/vpc'

--- a/lib/terrafying/components.rb
+++ b/lib/terrafying/components.rb
@@ -1,5 +1,5 @@
 
-require 'terrafying/components/ca'
+require 'terrafying/components/selfsignedca'
 require 'terrafying/components/letsencrypt'
 require 'terrafying/components/service'
 require 'terrafying/components/subnet'

--- a/lib/terrafying/components/ca.rb
+++ b/lib/terrafying/components/ca.rb
@@ -1,0 +1,46 @@
+
+module Terrafying
+
+  module Components
+
+    module CA
+
+      def create_keypair(name, options={})
+        create_keypair_in(self, name, options)
+      end
+
+      def reference_keypair(name)
+        key_ident = "#{@name}-#{name.gsub(/\./, '-')}"
+
+        {
+          name: name,
+          ca: self,
+          source: {
+            cert: File.join("s3://", @bucket, @prefix, @name, name, "cert"),
+            key: File.join("s3://", @bucket, @prefix, @name, name, "key"),
+          },
+          resources: [ "aws_s3_bucket_object.#{key_ident}-key", "aws_s3_bucket_object.#{key_ident}-cert" ],
+          iam_statement: {
+            Effect: "Allow",
+            Action: [
+              "s3:GetObjectAcl",
+              "s3:GetObject",
+            ],
+            Resource: [
+              "arn:aws:s3:::#{File.join(@bucket, @prefix, @name, "ca.cert")}",
+              "arn:aws:s3:::#{File.join(@bucket, @prefix, @name, name, "cert")}",
+              "arn:aws:s3:::#{File.join(@bucket, @prefix, @name, name, "key")}",
+            ]
+          }
+        }
+      end
+
+      def <=>(other)
+        @name <=> other.name
+      end
+
+    end
+
+  end
+
+end

--- a/lib/terrafying/components/ca.rb
+++ b/lib/terrafying/components/ca.rb
@@ -61,14 +61,7 @@ module Terrafying
         @ca_key = output_of(:tls_private_key, @ident, :private_key_pem)
         @ca_cert = output_of(:tls_self_signed_cert, @ident, :cert_pem)
 
-        @ca_keypair =
-
-          self
-      end
-
-
-      def iam_statement
-
+        self
       end
 
       def create_keypair(name, options={})

--- a/lib/terrafying/components/ca.rb
+++ b/lib/terrafying/components/ca.rb
@@ -123,6 +123,8 @@ module Terrafying
       end
 
       def reference_keypair(name)
+        key_ident = "#{@name}-#{name.gsub(/\./, '-')}"
+
         {
           name: name,
           ca: self,
@@ -130,6 +132,7 @@ module Terrafying
             cert: "s3://#{@bucket}/#{@prefix}/#{@name}/#{name}/cert",
             key: "s3://#{@bucket}/#{@prefix}/#{@name}/#{name}/key",
           },
+          resources: [ "aws_s3_bucket_object.#{key_ident}-key", "aws_s3_bucket_object.#{key_ident}-cert" ],
           iam_statement: {
             Effect: "Allow",
             Action: [

--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -85,9 +85,7 @@ module Terrafying
                                    lifecycle: {
                                      create_before_destroy: true,
                                    },
-                                   depends_on: [
-                                     "aws_iam_instance_profile.#{ident}",
-                                   ],
+                                   depends_on: options[:instance_profile] ? [options[:instance_profile].id] : [],
                                  }
 
         if options[:pivot]

--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -1,0 +1,128 @@
+
+require_relative './ports'
+
+module Terrafying
+
+  module Components
+
+    class DynamicSet < Terrafying::Context
+
+      attr_reader :name
+
+      def self.create_in(vpc, name, options={})
+        DynamicSet.new.create_in vpc, name, options
+      end
+
+      def self.find_in(vpc, name)
+        DynamicSet.new.find_in vpc, name
+      end
+
+      def initialize()
+        super
+      end
+
+      def find_in(vpc, name)
+        @name = "#{vpc.name}-#{name}"
+
+        self
+      end
+
+      def create_in(vpc, name, options={})
+        options = {
+          public: false,
+          ami: aws.ami("CoreOS-stable-1576.4.0-hvm", owners=["595879546273"]),
+          instance_type: "t2.micro",
+          ports: [],
+          instance_profile: nil,
+          security_groups: [],
+          tags: {},
+          ssh_group: vpc.ssh_group,
+          subnets: vpc.subnets.fetch(:private, []),
+          pivot: false,
+        }.merge(options)
+
+        ident = "#{vpc.name}-#{name}"
+
+        @name = ident
+
+        @security_group = resource :aws_security_group, ident, {
+                                     name: "dynamicset-#{ident}",
+                                     description: "Describe the ingress and egress of the service #{ident}",
+                                     tags: options[:tags],
+                                     vpc_id: vpc.id,
+                                     egress: [
+                                       {
+                                         from_port: 0,
+                                         to_port: 0,
+                                         protocol: -1,
+                                         cidr_blocks: ["0.0.0.0/0"],
+                                       }
+                                     ],
+                                   }
+
+
+        launch_config = resource :aws_launch_configuration, ident, {
+                                   name_prefix: "#{ident}-",
+                                   image_id: options[:ami],
+                                   instance_type: options[:instance_type],
+                                   user_data: options[:user_data],
+                                   iam_instance_profile: options[:instance_profile] && options[:instance_profile].id,
+                                   associate_public_ip_address: options[:public],
+                                   root_block_device: {
+                                     volume_type: 'gp2',
+                                     volume_size: 32,
+                                   },
+                                   security_groups: [
+                                     vpc.internal_ssh_security_group,
+                                     @security_group,
+                                   ].push(*options[:security_groups]),
+                                   lifecycle: {
+                                     create_before_destroy: true,
+                                   },
+                                   depends_on: [
+                                     "aws_iam_instance_profile.#{ident}",
+                                   ],
+                                 }
+
+        if options[:pivot]
+          options[:subnets].map.with_index { |subnet, i|
+            resource :aws_autoscaling_group, "#{ident}-#{i}", {
+                       name: "#{ident}-#{i}",
+                       launch_configuration: launch_config,
+                       min_size: options[:instances][:min],
+                       max_size: options[:instances][:max],
+                       desired_capacity: options[:instances][:desired],
+                       vpc_zone_identifier: [subnet.id],
+                       tags: {
+                         Name: ident,
+                         service_name: name,
+                       }.merge(options[:tags]).map { |k,v|
+                         { key: k, value: v, propagate_at_launch: true }
+                       },
+                     }.merge(target_groups ? {target_group_arns: target_groups} : {})
+          }
+        else
+          resource :aws_autoscaling_group, ident, {
+                     name: ident,
+                     launch_configuration: launch_config,
+                     min_size: options[:instances][:min],
+                     max_size: options[:instances][:max],
+                     desired_capacity: options[:instances][:desired],
+                     vpc_zone_identifier: options[:subnets].map(&:id),
+                     tags: {
+                       Name: ident,
+                       service_name: name,
+                     }.merge(options[:tags]).map { |k,v|
+                       { key: k, value: v, propagate_at_launch: true }
+                     },
+                   }.merge(options[:load_balancer] ? {target_group_arns: options[:load_balancer].target_groups} : {})
+        end
+
+        self
+      end
+
+    end
+
+  end
+
+end

--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -88,6 +88,8 @@ module Terrafying
                                    depends_on: options[:instance_profile] ? [options[:instance_profile].id] : [],
                                  }
 
+        target_groups = options[:load_balancer] ? {target_group_arns: options[:load_balancer].target_groups} : {}
+
         if options[:pivot]
           options[:subnets].map.with_index { |subnet, i|
             resource :aws_autoscaling_group, "#{ident}-#{i}", {
@@ -104,7 +106,7 @@ module Terrafying
                          { key: k, value: v, propagate_at_launch: true }
                        },
                        depends_on: options[:depends_on],
-                     }.merge(target_groups ? {target_group_arns: target_groups} : {})
+                     }.merge(target_groups)
           }
         else
           resource :aws_autoscaling_group, ident, {
@@ -121,7 +123,7 @@ module Terrafying
                        { key: k, value: v, propagate_at_launch: true }
                      },
                      depends_on: options[:depends_on],
-                   }.merge(options[:load_balancer] ? {target_group_arns: options[:load_balancer].target_groups} : {})
+                   }.merge(target_groups)
         end
 
         self

--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -39,6 +39,7 @@ module Terrafying
           ssh_group: vpc.ssh_group,
           subnets: vpc.subnets.fetch(:private, []),
           pivot: false,
+          depends_on: [],
         }.merge(options)
 
         ident = "#{vpc.name}-#{name}"
@@ -99,6 +100,7 @@ module Terrafying
                        }.merge(options[:tags]).map { |k,v|
                          { key: k, value: v, propagate_at_launch: true }
                        },
+                       depends_on: options[:depends_on],
                      }.merge(target_groups ? {target_group_arns: target_groups} : {})
           }
         else
@@ -115,6 +117,7 @@ module Terrafying
                      }.merge(options[:tags]).map { |k,v|
                        { key: k, value: v, propagate_at_launch: true }
                      },
+                     depends_on: options[:depends_on],
                    }.merge(options[:load_balancer] ? {target_group_arns: options[:load_balancer].target_groups} : {})
         end
 

--- a/lib/terrafying/components/ignition.rb
+++ b/lib/terrafying/components/ignition.rb
@@ -1,3 +1,5 @@
+require 'erb'
+require 'ostruct'
 
 module Terrafying
 
@@ -70,6 +72,25 @@ RestartSec=30
 
 EOF
         }
+      end
+
+      def self.generate(options={})
+        options = {
+          keypairs: [],
+          volumes: [],
+          files: [],
+          units: [],
+          ssh_group: "cloud",
+        }.merge(options)
+
+        options[:cas] = options[:keypairs].map { |kp| kp[:ca] }.sort.uniq
+
+        erb_path = File.join(File.dirname(__FILE__), "templates/ignition.yaml")
+        erb = ERB.new(IO.read(erb_path))
+
+        yaml = erb.result(OpenStruct.new(options).instance_eval { binding })
+
+        Terrafying::Util.to_ignition(yaml)
       end
 
     end

--- a/lib/terrafying/components/ignition.rb
+++ b/lib/terrafying/components/ignition.rb
@@ -1,0 +1,79 @@
+
+module Terrafying
+
+  module Components
+
+    class Ignition
+
+      def self.container_unit(name, image, options={})
+        options = {
+          volumes: [],
+          environment_variables: [],
+          arguments: [],
+          require_units: [],
+          host_networking: false,
+          privileged: false,
+        }.merge(options)
+
+        if options[:require_units].count > 0
+          require_units = options[:require_units].join(" ")
+          require = <<EOF
+After=#{require_units}
+Requires=#{require_units}
+EOF
+        end
+
+        docker_options = []
+
+        if options[:environment_variables].count > 0
+          docker_options += options[:environment_variables].map { |var|
+            "-e #{var}"
+          }
+        end
+
+        if options[:volumes].count > 0
+          docker_options += options[:volumes].map { |volume|
+            "-v #{volume}"
+          }
+        end
+
+        if options[:host_networking]
+          docker_options << "--net=host"
+        end
+
+        if options[:privileged]
+          docker_options << "--privileged"
+        end
+
+        docker_options_str = " \\\n" + docker_options.join(" \\\n")
+
+        if options[:arguments].count > 0
+          arguments = " \\\n" + options[:arguments].join(" \\\n")
+        end
+
+        {
+          name: "#{name}.service",
+          contents: <<EOF
+[Install]
+WantedBy=multi-user.target
+
+[Unit]
+Description=#{name}
+#{require}
+
+[Service]
+ExecStartPre=-/usr/bin/docker rm -f #{name}
+ExecStart=/usr/bin/docker run --name #{name} #{docker_options_str} \
+#{image} #{arguments}
+Restart=always
+RestartSec=30
+
+EOF
+        }
+      end
+
+    end
+
+  end
+
+end

--- a/lib/terrafying/components/instance.rb
+++ b/lib/terrafying/components/instance.rb
@@ -1,0 +1,63 @@
+
+module Terrafying
+
+  module Components
+
+    class Instance < Terrafying::Context
+
+      attr_reader :name, :ip_address
+
+      def self.create_in(vpc, name, options={})
+        Instance.new.create_in vpc, name, options
+      end
+
+      def self.find_in(vpc, name)
+        Instance.new.find_in vpc, name
+      end
+
+      def initialize()
+        super
+      end
+
+      def find_in(vpc, name)
+        raise 'unimplemented'
+      end
+
+      def create_in(vpc, name, options={})
+        options = {
+        }.merge(options)
+
+        ident = "#{vpc.name}-#{name}"
+
+        @name = name
+
+        resource :aws_instance, ident, {
+                   ami: options[:ami],
+                   instance_type: options[:instance_type],
+                   iam_instance_profile: options[:instance_profile] && options[:instance_profile].id,
+                   subnet_id: options[:subnet].id,
+                   associate_public_ip_address: options[:public],
+                   root_block_device: {
+                     volume_type: 'gp2',
+                     volume_size: 32,
+                   },
+                   tags: {
+                     'Name' => ident,
+                   }.merge(options[:tags]),
+                   vpc_security_group_ids: [
+                     vpc.internal_ssh_security_group,
+                   ].push(*options[:security_groups]),
+                   user_data: options[:user_data],
+                   lifecycle: {
+                     create_before_destroy: true,
+                   },
+                 }.merge(options[:ip_address] ? { private_ip: options[:ip_address] } : {}).merge(options[:lifecycle])
+
+        @ip_address = output_of(:aws_instance, ident, options[:public] ? :public_ip : :private_ip)
+
+        self
+      end
+
+    end
+  end
+end

--- a/lib/terrafying/components/instance.rb
+++ b/lib/terrafying/components/instance.rb
@@ -25,6 +25,7 @@ module Terrafying
 
       def create_in(vpc, name, options={})
         options = {
+          depends_on: [],
         }.merge(options)
 
         ident = "#{vpc.name}-#{name}"
@@ -51,6 +52,7 @@ module Terrafying
                    lifecycle: {
                      create_before_destroy: true,
                    },
+                   depends_on: options[:depends_on],
                  }.merge(options[:ip_address] ? { private_ip: options[:ip_address] } : {}).merge(options[:lifecycle])
 
         @ip_address = output_of(:aws_instance, ident, options[:public] ? :public_ip : :private_ip)

--- a/lib/terrafying/components/instance.rb
+++ b/lib/terrafying/components/instance.rb
@@ -1,11 +1,15 @@
 
+require 'terrafying/components/usable'
+
 module Terrafying
 
   module Components
 
     class Instance < Terrafying::Context
 
-      attr_reader :name, :ip_address
+      attr_reader :name, :ip_address, :security_group
+
+      include Usable
 
       def self.create_in(vpc, name, options={})
         Instance.new.create_in vpc, name, options
@@ -25,18 +29,59 @@ module Terrafying
 
       def create_in(vpc, name, options={})
         options = {
+          public: false,
+          instance_type: "t2.micro",
+          instance_profile: nil,
+          ports: [],
+          tags: {},
+          security_groups: [],
           depends_on: [],
         }.merge(options)
 
         ident = "#{vpc.name}-#{name}"
 
         @name = name
+        @ports = enrich_ports(options[:ports])
+
+        @security_group = resource :aws_security_group, ident, {
+                                     name: "instance-#{ident}",
+                                     description: "Describe the ingress and egress of the instance #{ident}",
+                                     tags: options[:tags],
+                                     vpc_id: vpc.id,
+                                     egress: [
+                                       {
+                                         from_port: 0,
+                                         to_port: 0,
+                                         protocol: -1,
+                                         cidr_blocks: ["0.0.0.0/0"],
+                                       }
+                                     ],
+                                   }
+
+        if options.has_key? :ip_address
+          lifecycle = {
+            lifecycle: { create_before_destroy: false },
+          }
+        else
+          lifecycle = {
+            lifecycle: { create_before_destroy: true },
+          }
+        end
+
+        if options.has_key? :subnet
+          subnet = options[:subnet]
+        else
+          subnets = options.fetch(:subnets, vpc.subnets[:private])
+          # pick something consistent but not just the first subnet
+          subnet_index = XXhash.xxh32(ident) % subnets.count
+          subnet = subnets[subnet_index]
+        end
 
         resource :aws_instance, ident, {
                    ami: options[:ami],
                    instance_type: options[:instance_type],
                    iam_instance_profile: options[:instance_profile] && options[:instance_profile].id,
-                   subnet_id: options[:subnet].id,
+                   subnet_id: subnet.id,
                    associate_public_ip_address: options[:public],
                    root_block_device: {
                      volume_type: 'gp2',
@@ -53,7 +98,7 @@ module Terrafying
                      create_before_destroy: true,
                    },
                    depends_on: options[:depends_on],
-                 }.merge(options[:ip_address] ? { private_ip: options[:ip_address] } : {}).merge(options[:lifecycle])
+                 }.merge(options[:ip_address] ? { private_ip: options[:ip_address] } : {}).merge(lifecycle)
 
         @ip_address = output_of(:aws_instance, ident, options[:public] ? :public_ip : :private_ip)
 

--- a/lib/terrafying/components/instanceprofile.rb
+++ b/lib/terrafying/components/instanceprofile.rb
@@ -1,0 +1,81 @@
+
+module Terrafying
+
+  module Components
+
+    class InstanceProfile < Terrafying::Context
+
+      attr_reader :id
+
+      def self.create(name, options={})
+        InstanceProfile.new.create name, options
+      end
+
+      def self.find(name)
+        InstanceProfile.new.find name
+      end
+
+      def initialize()
+        super
+      end
+
+      def find(name)
+        raise 'unimplemented'
+      end
+
+      def create(name, options={})
+        options = {
+          statements: [],
+        }.merge(options)
+
+        resource :aws_iam_role, name, {
+                   name: name,
+                   assume_role_policy: JSON.pretty_generate(
+                     {
+                       Version: "2012-10-17",
+                       Statement: [
+                         {
+                           Effect: "Allow",
+                           Principal: { "Service": "ec2.amazonaws.com"},
+                           Action: "sts:AssumeRole"
+                         }
+                       ]
+                     }
+                   )
+                 }
+
+        resource :aws_iam_role_policy, name, {
+                   name: name,
+                   policy: JSON.pretty_generate(
+                     {
+                       Version: "2012-10-17",
+                       Statement: [
+                         {
+                           Sid: "Stmt1442396947000",
+                           Effect: "Allow",
+                           Action: [
+                             "iam:GetGroup",
+                             "iam:GetSSHPublicKey",
+                             "iam:GetUser",
+                             "iam:ListSSHPublicKeys"
+                           ],
+                           Resource: [
+                             "arn:aws:iam::*"
+                           ]
+                         }
+                       ].push(*options[:statements])
+                     }
+                   ),
+                   role: output_of(:aws_iam_role, name, :name)
+                 }
+
+        @id = resource :aws_iam_instance_profile, name, {
+                         name: name,
+                         role: output_of(:aws_iam_role, name, :name),
+                       }
+
+        self
+      end
+    end
+  end
+end

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -121,6 +121,8 @@ module Terrafying
       end
 
       def reference_keypair(name)
+        key_ident = "#{@name}-#{name.gsub(/\./, '-')}"
+
         {
           name: name,
           ca: self,
@@ -128,6 +130,7 @@ module Terrafying
             cert: File.join("s3://", @bucket, @prefix, @name, name, "cert"),
             key: File.join("s3://", @bucket, @prefix, @name, name, "key"),
           },
+          resources: [ "aws_s3_bucket_object.#{key_ident}-key", "aws_s3_bucket_object.#{key_ident}-cert" ],
           iam_statement: {
             Effect: "Allow",
             Action: [

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -1,4 +1,5 @@
 
+require 'terrafying/components/ca'
 require 'terrafying/generator'
 
 module Terrafying
@@ -8,6 +9,8 @@ module Terrafying
     class LetsEncrypt < Terrafying::Context
 
       attr_reader :name, :source
+
+      include CA
 
       def self.create(bucket, options={})
         LetsEncrypt.new.create bucket, options
@@ -57,10 +60,6 @@ module Terrafying
         @source = File.join("s3://", @bucket, @prefix, @name, "ca.cert")
 
         self
-      end
-
-      def create_keypair(name, options={})
-        create_keypair_in(self, name, options)
       end
 
       def create_keypair_in(ctx, name, options={})
@@ -118,36 +117,6 @@ module Terrafying
                      }
 
         reference_keypair(name)
-      end
-
-      def reference_keypair(name)
-        key_ident = "#{@name}-#{name.gsub(/\./, '-')}"
-
-        {
-          name: name,
-          ca: self,
-          source: {
-            cert: File.join("s3://", @bucket, @prefix, @name, name, "cert"),
-            key: File.join("s3://", @bucket, @prefix, @name, name, "key"),
-          },
-          resources: [ "aws_s3_bucket_object.#{key_ident}-key", "aws_s3_bucket_object.#{key_ident}-cert" ],
-          iam_statement: {
-            Effect: "Allow",
-            Action: [
-              "s3:GetObjectAcl",
-              "s3:GetObject",
-            ],
-            Resource: [
-              "arn:aws:s3:::#{File.join(@bucket, @prefix, @name, "ca.cert")}",
-              "arn:aws:s3:::#{File.join(@bucket, @prefix, @name, name, "cert")}",
-              "arn:aws:s3:::#{File.join(@bucket, @prefix, @name, name, "key")}",
-            ]
-          }
-        }
-      end
-
-      def <=>(other)
-        @name <=> other.name
       end
 
     end

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -1,0 +1,152 @@
+
+require 'terrafying/generator'
+
+module Terrafying
+
+  module Components
+
+    class LetsEncrypt < Terrafying::Context
+
+      attr_reader :name, :source
+
+      def self.create(bucket, options={})
+        LetsEncrypt.new.create bucket, options
+      end
+
+      def initialize()
+        super
+      end
+
+      def create(bucket, options={})
+        options = {
+          prefix: "",
+          server_url: "https://acme-staging.api.letsencrypt.org/directory",
+          email_address: "cloud@uswitch.com",
+        }.merge(options)
+
+        @name = "letsencrypt"
+        @bucket = bucket
+        @prefix = options[:prefix]
+        @server_url = options[:server_url]
+
+        resource :tls_private_key, "#{@name}-account", {
+                   algorithm: "ECDSA",
+                   ecdsa_curve: "P384",
+                 }
+
+        @account_key = output_of(:tls_private_key, "#{@name}-account", "private_key_pem")
+
+        @registration_url = resource :acme_registration, "#{@name}-reg", {
+                                       server_url: @server_url,
+                                       account_key_pem: @account_key,
+                                       email_address: options[:email_address],
+                                     }
+
+        resource :aws_s3_bucket_object, "#{@name}-account", {
+                   bucket: @bucket,
+                   key: File.join(@prefix, @name, "account.key"),
+                   content: @account_key,
+                 }
+
+        resource :aws_s3_bucket_object, "#{@name}-cert", {
+                   bucket: @bucket,
+                   key: File.join(@prefix, @name, "ca.cert"),
+                   content: "",
+                 }
+
+        @source = File.join("s3://", @bucket, @prefix, @name, "ca.cert")
+
+        self
+      end
+
+      def create_keypair(name, options={})
+        create_keypair_in(self, name, options)
+      end
+
+      def create_keypair_in(ctx, name, options={})
+        options = {
+          common_name: name,
+          organization: "uSwitch Limited",
+          validity_in_hours: 24 * 365,
+          allowed_uses: [
+            "nonRepudiation",
+            "digitalSignature",
+            "keyEncipherment"
+          ],
+          dns_names: [],
+          ip_addresses: [],
+        }.merge(options)
+
+        key_ident = "#{@name}-#{name.gsub(/\./, '-')}"
+
+        ctx.resource :tls_private_key, key_ident, {
+                       algorithm: "ECDSA",
+                       ecdsa_curve: "P384",
+                     }
+
+        ctx.resource :tls_cert_request, key_ident, {
+                       key_algorithm: "ECDSA",
+                       private_key_pem: output_of(:tls_private_key, key_ident, :private_key_pem),
+                       subject: {
+                         common_name: options[:common_name],
+                         organization: options[:organization],
+                       },
+                       dns_names: options[:dns_names],
+                       ip_addresses: options[:ip_addresses],
+                     }
+
+        ctx.resource :acme_certificate, key_ident, {
+                       server_url: @server_url,
+                       account_key_pem: @account_key,
+                       registration_url: @registration_url,
+                       dns_challenge: {
+                         provider: "route53",
+                       },
+                       certificate_request_pem: output_of(:tls_cert_request, key_ident, :cert_request_pem),
+                     }
+
+        ctx.resource :aws_s3_bucket_object, "#{key_ident}-key", {
+                       bucket: @bucket,
+                       key: File.join(@prefix, @name, name, "key"),
+                       content: output_of(:tls_private_key, key_ident, :private_key_pem),
+                     }
+
+        ctx.resource :aws_s3_bucket_object, "#{key_ident}-cert", {
+                       bucket: @bucket,
+                       key: File.join(@prefix, @name, name, "cert"),
+                       content: output_of(:acme_certificate, key_ident, :certificate_pem),
+                     }
+
+        reference_keypair(name)
+      end
+
+      def reference_keypair(name)
+        {
+          name: name,
+          ca: self,
+          source: {
+            cert: File.join("s3://", @bucket, @prefix, @name, name, "cert"),
+            key: File.join("s3://", @bucket, @prefix, @name, name, "key"),
+          },
+          iam_statement: {
+            Effect: "Allow",
+            Action: [
+              "s3:GetObjectAcl",
+              "s3:GetObject",
+            ],
+            Resource: [
+              "arn:aws:s3:::#{File.join(@bucket, @prefix, @name, "ca.cert")}",
+              "arn:aws:s3:::#{File.join(@bucket, @prefix, @name, name, "cert")}",
+              "arn:aws:s3:::#{File.join(@bucket, @prefix, @name, name, "key")}",
+            ]
+          }
+        }
+      end
+
+      def <=>(other)
+        @name <=> other.name
+      end
+
+    end
+  end
+end

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -17,14 +17,14 @@ module Terrafying
         super
       end
 
-      def create(bucket, options={})
+      def create(name, bucket, options={})
         options = {
           prefix: "",
           server_url: "https://acme-staging.api.letsencrypt.org/directory",
           email_address: "cloud@uswitch.com",
         }.merge(options)
 
-        @name = "letsencrypt"
+        @name = name
         @bucket = bucket
         @prefix = options[:prefix]
         @server_url = options[:server_url]

--- a/lib/terrafying/components/loadbalancer.rb
+++ b/lib/terrafying/components/loadbalancer.rb
@@ -41,11 +41,11 @@ module Terrafying
 
         l4_ports = @ports.select{ |p| is_l4_port(p) }
 
-        if l4_ports.count > 0 && l4_ports.count < ports.count
+        if l4_ports.count > 0 && l4_ports.count < @ports.count
           raise 'Ports have to either be all layer 4 or 7'
         end
 
-        @type = l4_ports == 0 ? "application" : "network"
+        @type = l4_ports.count == 0 ? "application" : "network"
 
         ident = "#{type}-#{vpc.name}-#{name}"
 

--- a/lib/terrafying/components/loadbalancer.rb
+++ b/lib/terrafying/components/loadbalancer.rb
@@ -1,0 +1,118 @@
+
+require_relative './ports'
+
+module Terrafying
+
+  module Components
+
+    class LoadBalancer < Terrafying::Context
+
+      attr_reader :id, :type, :target_groups, :alias_config
+
+      def self.create_in(vpc, name, ports, options={})
+        LoadBalancer.new.create_in vpc, name, ports, options
+      end
+
+      def self.find_in(vpc, name)
+        LoadBalancer.new.find_in vpc, name
+      end
+
+      def initialize()
+        super
+      end
+
+      def find_in(vpc, name)
+        raise 'unimplemented'
+      end
+
+      def create_in(vpc, name, ports, options={})
+        options = {
+          public: false,
+          subnets: vpc.subnets.fetch(:private, []),
+          tags: {},
+        }.merge(options)
+
+        ports = enrich_ports(ports)
+
+        l4_ports = ports.select{ |p| is_l4_port(p) }
+
+        if l4_ports.count > 0 && l4_ports.count < ports.count
+          raise 'Ports have to either be all layer 4 or 7'
+        end
+
+        @type = l4_ports == 0 ? "application" : "network"
+
+        ident = "#{type}-#{vpc.name}-#{name}"
+
+        if @type == "application"
+          @security_group = resource :aws_security_group, ident, {
+                                       name: "loadbalancer-#{ident}",
+                                       description: "Describe the ingress and egress of the load balancer #{ident}",
+                                       tags: options[:tags],
+                                       vpc_id: vpc.id,
+                                     }
+        end
+
+        @id = resource :aws_lb, ident, {
+                         name: ident,
+                         load_balancer_type: type,
+                         internal: !options[:public],
+                         subnets: options[:subnets].map(&:id),
+                         tags: options[:tags],
+                       }.merge(@type == "application" ? { security_groups: [@security_group] } : {})
+
+        @target_groups = []
+
+        ports.each { |port|
+          port_ident = "#{ident}-#{port[:type]}-#{port[:number]}"
+
+          target_group = resource :aws_lb_target_group, port_ident, {
+                                    name: port_ident,
+                                    port: port[:number],
+                                    protocol: port[:type].upcase,
+                                    vpc_id: vpc.id,
+                                  }.merge(port.has_key?(:health_check) ? { health_check: port[:health_check] }: {})
+
+          ssl_options = {}
+          if port.has_key?(:ssl_certificate)
+            ssl_options = {
+              ssl_policy: "ELBSecurityPolicy-2015-05",
+              certificate_arn: port[:ssl_certificate],
+            }
+          end
+
+          resource :aws_lb_listener, port_ident, {
+                     load_balancer_arn: @id,
+                     port: port[:number],
+                     protocol: port[:type].upcase,
+                     default_action: {
+                       target_group_arn: target_group,
+                       type: "forward",
+                     },
+                   }.merge(ssl_options)
+
+          @target_groups << target_group
+        }
+
+        @alias_config = {
+          name: output_of(:aws_lb, ident, :dns_name),
+          zone_id: output_of(:aws_lb, ident, :zone_id),
+          evaluate_target_health: true,
+        }
+
+        self
+      end
+
+      def used_by(*service)
+        raise 'unimplemented'
+      end
+
+      def used_by_cidr(*cidrs)
+        raise 'unimplmeneted'
+      end
+
+    end
+
+  end
+
+end

--- a/lib/terrafying/components/ports.rb
+++ b/lib/terrafying/components/ports.rb
@@ -1,0 +1,30 @@
+
+PORT_NAMES = {
+  22 => "ssh",
+  80 => "http",
+  443 => "https",
+  1194 => "openvpn",
+}
+
+def enrich_ports(ports)
+  ports.map { |port|
+    if port.is_a?(Numeric)
+      port = { number: port }
+    end
+
+    port = {
+      type: "tcp",
+      name: PORT_NAMES.fetch(port[:number], port[:number].to_s),
+    }.merge(port)
+
+    port
+  }
+end
+
+def is_l4_port(port)
+  port[:type] == "tcp" || port[:type] == "udp"
+end
+
+def is_l7_port(port)
+  port[:type] == "http" || port[:type] == "https"
+end

--- a/lib/terrafying/components/selfsignedca.rb
+++ b/lib/terrafying/components/selfsignedca.rb
@@ -1,4 +1,5 @@
 
+require 'terrafying/components/ca'
 require 'terrafying/generator'
 
 module Terrafying
@@ -8,6 +9,8 @@ module Terrafying
     class SelfSignedCA < Terrafying::Context
 
       attr_reader :name, :source, :ca_key
+
+      include CA
 
       def self.create(name, bucket, options={})
         SelfSignedCA.new.create name, bucket, options
@@ -64,9 +67,6 @@ module Terrafying
         self
       end
 
-      def create_keypair(name, options={})
-        create_keypair_in(self, name, options)
-      end
 
       def create_keypair_in(ctx, name, options={})
         options = {
@@ -122,36 +122,6 @@ module Terrafying
                      }
 
         reference_keypair(name)
-      end
-
-      def reference_keypair(name)
-        key_ident = "#{@name}-#{name.gsub(/\./, '-')}"
-
-        {
-          name: name,
-          ca: self,
-          source: {
-            cert: File.join("s3://", @bucket, @prefix, @name, name, "cert"),
-            key: File.join("s3://", @bucket, @prefix, @name, name, "key"),
-          },
-          resources: [ "aws_s3_bucket_object.#{key_ident}-key", "aws_s3_bucket_object.#{key_ident}-cert" ],
-          iam_statement: {
-            Effect: "Allow",
-            Action: [
-              "s3:GetObjectAcl",
-              "s3:GetObject",
-            ],
-            Resource: [
-              "arn:aws:s3:::#{File.join(@bucket, @prefix, @name, "ca.cert")}",
-              "arn:aws:s3:::#{File.join(@bucket, @prefix, @name, name, "cert")}",
-              "arn:aws:s3:::#{File.join(@bucket, @prefix, @name, name, "key")}",
-            ]
-          }
-        }
-      end
-
-      def <=>(other)
-        @name <=> other.name
       end
 
     end

--- a/lib/terrafying/components/selfsignedca.rb
+++ b/lib/terrafying/components/selfsignedca.rb
@@ -5,12 +5,12 @@ module Terrafying
 
   module Components
 
-    class CA < Terrafying::Context
+    class SelfSignedCA < Terrafying::Context
 
       attr_reader :name, :source, :ca_key
 
       def self.create(name, bucket, options={})
-        CA.new.create name, bucket, options
+        SelfSignedCA.new.create name, bucket, options
       end
 
       def initialize()
@@ -52,11 +52,11 @@ module Terrafying
 
         resource :aws_s3_bucket_object, "#{@ident}-cert", {
                    bucket: @bucket,
-                   key: "#{@prefix}/#{@name}/ca.cert",
+                   key: File.join(@prefix, @name, "ca.cert"),
                    content: output_of(:tls_self_signed_cert, @ident, :cert_pem),
                  }
 
-        @source = "s3://#{@bucket}/#{@prefix}/#{@name}/ca.cert"
+        @source = File.join("s3://", @bucket, @prefix, @name, "ca.cert")
 
         @ca_key = output_of(:tls_private_key, @ident, :private_key_pem)
         @ca_cert = output_of(:tls_self_signed_cert, @ident, :cert_pem)
@@ -65,6 +65,10 @@ module Terrafying
       end
 
       def create_keypair(name, options={})
+        create_keypair_in(self, name, options)
+      end
+
+      def create_keypair_in(ctx, name, options={})
         options = {
           common_name: name,
           organization: "uSwitch Limited",
@@ -78,46 +82,44 @@ module Terrafying
           ip_addresses: [],
         }.merge(options)
 
-        key_ident = "#{@ident}-#{name}"
+        key_ident = "#{@name}-#{name}"
 
-        resource :tls_private_key, key_ident, {
-                   algorithm: "ECDSA",
-                   ecdsa_curve: "P384",
-                 }
+        ctx.resource :tls_private_key, key_ident, {
+                       algorithm: "ECDSA",
+                       ecdsa_curve: "P384",
+                     }
 
-        resource :tls_cert_request, key_ident, {
-                   key_algorithm: "ECDSA",
-                   private_key_pem: output_of(:tls_private_key, key_ident, :private_key_pem),
-                   subject: {
-                     common_name: options[:common_name],
-                     organization: options[:organization],
-                   },
-                   dns_names: options[:dns_names],
-                   ip_addresses: options[:ip_addresses],
-                 }
+        ctx.resource :tls_cert_request, key_ident, {
+                       key_algorithm: "ECDSA",
+                       private_key_pem: output_of(:tls_private_key, key_ident, :private_key_pem),
+                       subject: {
+                         common_name: options[:common_name],
+                         organization: options[:organization],
+                       },
+                       dns_names: options[:dns_names],
+                       ip_addresses: options[:ip_addresses],
+                     }
 
-        resource :tls_locally_signed_cert, key_ident, {
-                   cert_request_pem: output_of(:tls_cert_request, key_ident, :cert_request_pem),
-                   ca_key_algorithm: "ECDSA",
-                   ca_private_key_pem: @ca_key,
-                   ca_cert_pem: @ca_cert,
-                   validity_period_hours: options[:validity_in_hours],
-                   allowed_uses: options[:allowed_uses],
-                 }
+        ctx.resource :tls_locally_signed_cert, key_ident, {
+                       cert_request_pem: output_of(:tls_cert_request, key_ident, :cert_request_pem),
+                       ca_key_algorithm: "ECDSA",
+                       ca_private_key_pem: @ca_key,
+                       ca_cert_pem: @ca_cert,
+                       validity_period_hours: options[:validity_in_hours],
+                       allowed_uses: options[:allowed_uses],
+                     }
 
-        keypair_path = "#{@prefix}/#{@name}/#{name}"
+        ctx.resource :aws_s3_bucket_object, "#{key_ident}-key", {
+                       bucket: @bucket,
+                       key: File.join(@prefix, @name, name, "key"),
+                       content: output_of(:tls_private_key, key_ident, :private_key_pem),
+                     }
 
-        resource :aws_s3_bucket_object, "#{key_ident}-key", {
-                   bucket: @bucket,
-                   key: "#{keypair_path}/key",
-                   content: output_of(:tls_private_key, key_ident, :private_key_pem),
-                 }
-
-        resource :aws_s3_bucket_object, "#{key_ident}-cert", {
-                   bucket: @bucket,
-                   key: "#{keypair_path}/cert",
-                   content: output_of(:tls_locally_signed_cert, key_ident, :cert_pem),
-                 }
+        ctx.resource :aws_s3_bucket_object, "#{key_ident}-cert", {
+                       bucket: @bucket,
+                       key: File.join(@prefix, @name, name, "cert"),
+                       content: output_of(:tls_locally_signed_cert, key_ident, :cert_pem),
+                     }
 
         reference_keypair(name)
       end
@@ -129,8 +131,8 @@ module Terrafying
           name: name,
           ca: self,
           source: {
-            cert: "s3://#{@bucket}/#{@prefix}/#{@name}/#{name}/cert",
-            key: "s3://#{@bucket}/#{@prefix}/#{@name}/#{name}/key",
+            cert: File.join("s3://", @bucket, @prefix, @name, name, "cert"),
+            key: File.join("s3://", @bucket, @prefix, @name, name, "key"),
           },
           resources: [ "aws_s3_bucket_object.#{key_ident}-key", "aws_s3_bucket_object.#{key_ident}-cert" ],
           iam_statement: {
@@ -140,9 +142,9 @@ module Terrafying
               "s3:GetObject",
             ],
             Resource: [
-              "arn:aws:s3:::#{@bucket}/#{@prefix}/#{@name}/ca.cert",
-              "arn:aws:s3:::#{@bucket}/#{@prefix}/#{@name}/#{name}/cert",
-              "arn:aws:s3:::#{@bucket}/#{@prefix}/#{@name}/#{name}/key",
+              "arn:aws:s3:::#{File.join(@bucket, @prefix, @name, "ca.cert")}",
+              "arn:aws:s3:::#{File.join(@bucket, @prefix, @name, name, "cert")}",
+              "arn:aws:s3:::#{File.join(@bucket, @prefix, @name, name, "key")}",
             ]
           }
         }

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -73,13 +73,13 @@ module Terrafying
 
         if options[:instances].is_a?(Hash)
 
-          @load_balancer = add! LoadBalancer.create_in(vpc, name, options[:ports], options)
+          @load_balancer = add! LoadBalancer.create_in(vpc, name, options)
           @instance_set = add! DynamicSet.create_in(
                                  vpc, name, options.merge({
                                    instance_profile: instance_profile,
                                    load_balancer: @load_balancer,
                                    depends_on: depends_on,
-                                 })
+                                 }),
                                )
 
           if @load_balancer == "application"
@@ -93,10 +93,12 @@ module Terrafying
         elsif options[:instances].is_a?(Array)
 
           @instance_set = add! StaticSet.create_in(
-                                 vpc, name, options.merge({
-                                   instance_profile: instance_profile,
-                                   depends_on: depends_on,
-                                                          }))
+                                 vpc, name, options.merge(
+                                   {
+                                     instance_profile: instance_profile,
+                                     depends_on: depends_on,
+                                   }),
+                               )
 
           @security_group = @instance_set.security_group
 

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -148,7 +148,6 @@ module Terrafying
                                       role: output_of(:aws_iam_role, ident, :name),
                                     }
 
-
         if options[:instances].is_a?(Hash)
 
           if @ports.count > 0

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -1,39 +1,13 @@
 
 require 'digest'
-require 'xxhash'
 require 'terrafying/generator'
 require 'terrafying/util'
-
-PORT_NAMES = {
-  22 => "ssh",
-  80 => "http",
-  443 => "https",
-  1194 => "openvpn",
-}
-
-def enrich_ports(ports)
-  ports.map { |port|
-    if port.is_a?(Numeric)
-      port = { number: port }
-    end
-
-    port = {
-      type: "tcp",
-      name: PORT_NAMES.fetch(port[:number], port[:number].to_s),
-    }.merge(port)
-
-    port
-  }
-end
-
-def is_l4_port(port)
-  port[:type] == "tcp" || port[:type] == "udp"
-end
-
-def is_l7_port(port)
-  port[:type] == "http" || port[:type] == "https"
-end
-
+require 'terrafying/components/dynamicset'
+require 'terrafying/components/ignition'
+require 'terrafying/components/instance'
+require 'terrafying/components/instanceprofile'
+require 'terrafying/components/loadbalancer'
+require 'terrafying/components/staticset'
 
 module Terrafying
 
@@ -41,23 +15,28 @@ module Terrafying
 
     class Service < Terrafying::Context
 
-      attr_reader :name, :ids, :fqdn, :instance_fqdns, :instance_security_group
+      attr_reader :name, :domain_names
 
       def self.create_in(vpc, name, options={})
         Service.new.create_in vpc, name, options
+      end
+
+      def self.find_in(vpc, name)
+        Service.new.find_in vpc, name
       end
 
       def initialize()
         super
       end
 
+      def find_in(vpc, name)
+        raise 'unimplemented'
+      end
 
       def create_in(vpc, name, options={})
         options = {
           ami: aws.ami("CoreOS-stable-1576.4.0-hvm", owners=["595879546273"]),
           instance_type: "t2.micro",
-          public: false,
-          internet_egress: false,
           ports: [],
           instances: [{}],
           zone: vpc.zone,
@@ -69,383 +48,45 @@ module Terrafying
           files: [],
           tags: {},
           ssh_group: vpc.ssh_group,
-          subnets: nil,
+          subnets: vpc.subnets.fetch(:private, []),
           pivot: false,
+          privatelink: false,
         }.merge(options)
 
         if ! options.has_key? :user_data
-          options[:user_data] = user_data(options)
+          options[:user_data] = Ignition.generate(options)
         end
 
         ident = "#{vpc.name}-#{name}"
 
         @name = ident
-        @fqdn = options[:zone].qualify(name)
-        @instance_fqdns = []
-        @ports = enrich_ports(options[:ports])
-        @ssh_group = options[:ssh_group]
+        @domain_names = [ options[:zone].qualify(name) ]
 
-        if options[:subnets]
-          subnets = options[:subnets]
-        elsif options[:public]
-          subnets = vpc.public_subnets
-        else
-          subnets = vpc.private_subnets
-        end
-
-        @access_security_group = resource :aws_security_group, ident, {
-                                            name: "service-#{ident}",
-                                            description: "Describe the ingress and egress of the service #{ident}",
-                                            tags: options[:tags],
-                                            vpc_id: vpc.id,
-                                            egress: [
-                                              {
-                                                from_port: 0,
-                                                to_port: 0,
-                                                protocol: -1,
-                                                cidr_blocks: [options[:internet_egress] ? vpc.cidr : "0.0.0.0/0"],
-                                              }
-                                            ],
-                                          }
-
-        resource :aws_iam_role, ident, {
-                   name: ident,
-                   assume_role_policy: JSON.pretty_generate({
-                                                              Version: "2012-10-17",
-                                                              Statement: [
-                                                                {
-                                                                  Effect: "Allow",
-                                                                  Principal: { "Service": "ec2.amazonaws.com"},
-                                                                  Action: "sts:AssumeRole"
-                                                                }
-                                                              ]
-                                                            })
-                 }
-        resource :aws_iam_role_policy, ident, {
-                   name: ident,
-                   policy: JSON.pretty_generate({
-                                                  Version: "2012-10-17",
-                                                  Statement: [
-                                                    {
-                                                      Sid: "Stmt1442396947000",
-                                                      Effect: "Allow",
-                                                      Action: [
-                                                        "iam:GetGroup",
-                                                        "iam:GetSSHPublicKey",
-                                                        "iam:GetUser",
-                                                        "iam:ListSSHPublicKeys"
-                                                      ],
-                                                      Resource: [
-                                                        "arn:aws:iam::*"
-                                                      ]
-                                                    }
-                                                  ].push(*options[:keypairs].map{|kp| kp[:iam_statement]}).push(*options[:iam_policy_statements])
-                                                }),
-                   role: output_of(:aws_iam_role, ident, :name)
-                 }
-        instance_profile = resource :aws_iam_instance_profile, ident, {
-                                      name: ident,
-                                      role: output_of(:aws_iam_role, ident, :name),
-                                    }
+        iam_statements = options[:iam_policy_statements] + options[:keypairs].map { |kp| kp[:iam_statement] }
+        instance_profile = add! InstanceProfile.create(ident, { statements: iam_statements })
 
         if options[:instances].is_a?(Hash)
 
-          if @ports.count > 0
-            l4_ports = @ports.select { |p| is_l4_port(p) }
-            l7_ports = @ports.select { |p| is_l7_port(p) }
+          @load_balancer = add! LoadBalancer.create_in(vpc, name, options[:ports], options)
+          @instance_set = add! DynamicSet.create_in(
+                                 vpc, name, options.merge({
+                                   instance_profile: instance_profile,
+                                   load_balancer: @load_balancer,
+                                 })
+                               )
 
-            target_groups = []
-
-
-            @instance_security_group = resource :aws_security_group, "asg-#{ident}", {
-                                                  name: "asg-#{ident}",
-                                                  description: "Describe the ingress and egress of the service asg #{ident}",
-                                                  tags: options[:tags],
-                                                  vpc_id: vpc.id,
-                                                  egress: [
-                                                    {
-                                                      from_port: 0,
-                                                      to_port: 0,
-                                                      protocol: -1,
-                                                      cidr_blocks: [options[:internet_egress] ? vpc.cidr : "0.0.0.0/0"],
-                                                    }
-                                                  ],
-                                                }
-
-
-            if l4_ports.count > 0
-              network_load_balancer = resource :aws_lb, "nlb-#{ident}", {
-                                                 name: "nlb-#{ident}",
-                                                 load_balancer_type: "network",
-                                                 internal: !options[:public],
-                                                 subnets: subnets.map(&:id),
-                                                 tags: options[:tags],
-                                               }
-
-              l4_ports.each { |l4_port|
-                port_ident = "nlb-#{ident}-#{l4_port[:type]}-#{l4_port[:number]}"
-                target_group = resource :aws_lb_target_group, port_ident, {
-                                          name: port_ident,
-                                          port: l4_port[:number],
-                                          protocol: l4_port[:type].upcase,
-                                          vpc_id: vpc.id,
-                                        }.merge(l4_port.has_key?(:health_check) ? { health_check: l4_port[:health_check] }: {})
-
-                resource :aws_security_group_rule, port_ident, {
-                           security_group_id: @instance_security_group,
-                           type: "ingress",
-                           from_port: l4_port[:number],
-                           to_port: l4_port[:number],
-                           protocol: l4_port[:type],
-                           cidr_blocks: [ vpc.cidr ], # until we can get the ips for the nlb it has to be all vpc
-                         }
-
-                resource :aws_lb_listener, port_ident, {
-                           load_balancer_arn: network_load_balancer,
-                           port: l4_port[:number],
-                           protocol: l4_port[:type].upcase,
-                           default_action: {
-                             target_group_arn: target_group,
-                             type: "forward",
-                           },
-                         }
-
-                l4_port[:security_group] = @instance_security_group
-
-                target_groups << target_group
-              }
-            end
-
-            if l7_ports.count > 0
-              application_load_balancer = resource :aws_lb, "alb-#{ident}", {
-                                                     name: "alb-#{ident}",
-                                                     load_balancer_type: "application",
-                                                     security_groups: [@access_security_group],
-                                                     internal: !options[:public],
-                                                     subnets: subnets.map(&:id),
-                                                     tags: options[:tags],
-                                                   }
-
-              l7_ports.each { |l7_port|
-                port_ident = "alb-#{ident}-#{l7_port[:type]}-#{l7_port[:number]}"
-                target_group = resource :aws_lb_target_group, port_ident, {
-                                          name: port_ident,
-                                          port: l7_port[:number],
-                                          protocol: l7_port[:type].upcase,
-                                          vpc_id: vpc.id,
-                                        }.merge(l7_port.has_key?(:health_check) ? { health_check: l7_port[:health_check] }: {})
-
-                resource :aws_security_group_rule, port_ident, {
-                           security_group_id: @instance_security_group,
-                           type: "ingress",
-                           from_port: l7_port[:number],
-                           to_port: l7_port[:number],
-                           protocol: "tcp",
-                           source_security_group_ids: [
-                             @access_security_group,
-                           ],
-                         }
-
-                ssl_options = {}
-                if l7_port.has_key?(:ssl_certificate)
-                  ssl_options = {
-                    ssl_policy: "ELBSecurityPolicy-2015-05",
-                    certificate_arn: l7_port[:ssl_certificate],
-                  }
-                end
-
-                resource :aws_lb_listener, port_ident, {
-                           load_balancer_arn: application_load_balancer,
-                           port: l7_port[:number],
-                           protocol: l7_port[:type].upcase,
-                           default_action: {
-                             target_group_arn: target_group,
-                             type: "forward",
-                           },
-                         }.merge(ssl_options)
-
-                target_groups << target_group
-              }
-            end
-
-            if application_load_balancer
-              options[:zone].add_alias(
-                name,
-                {
-                  name: output_of(:aws_lb, "alb-#{ident}", :dns_name),
-                  zone_id: output_of(:aws_lb, "alb-#{ident}", :zone_id),
-                  evaluate_target_health: true,
-                },
-              )
-            elsif network_load_balancer
-              options[:zone].add_alias(
-                name,
-                {
-                  name: output_of(:aws_lb, "nlb-#{ident}", :dns_name),
-                  zone_id: output_of(:aws_lb, "nlb-#{ident}", :zone_id),
-                  evaluate_target_health: true,
-                },
-              )
-            end
-          else
-            @instance_security_group = @access_security_group
-          end
-
-          launch_config = resource :aws_launch_configuration, ident, {
-                                     name_prefix: "#{ident}-",
-                                     image_id: options[:ami],
-                                     instance_type: options[:instance_type],
-                                     user_data: options[:user_data],
-                                     iam_instance_profile: instance_profile,
-                                     associate_public_ip_address: options[:public],
-                                     root_block_device: {
-                                       volume_type: 'gp2',
-                                       volume_size: 32,
-                                     },
-                                     security_groups: [
-                                       vpc.internal_ssh_security_group,
-                                       @instance_security_group,
-                                     ].push(*options[:security_groups]),
-                                     lifecycle: {
-                                       create_before_destroy: true,
-                                     },
-                                     depends_on: [
-                                       "aws_iam_instance_profile.#{ident}",
-                                     ],
-                                   }
-
-          if options[:pivot]
-            @ids = subnets.map.with_index { |subnet, i|
-              resource :aws_autoscaling_group, "#{ident}-#{i}", {
-                         name: "#{ident}-#{i}",
-                         launch_configuration: launch_config,
-                         min_size: options[:instances][:min],
-                         max_size: options[:instances][:max],
-                         desired_capacity: options[:instances][:desired],
-                         vpc_zone_identifier: [subnet.id],
-                         tags: {
-                           Name: ident,
-                           service_name: name,
-                         }.merge(options[:tags]).map { |k,v|
-                           { key: k, value: v, propagate_at_launch: true }
-                         },
-                       }.merge(target_groups ? {target_group_arns: target_groups} : {})
-            }
-          else
-            asg = resource :aws_autoscaling_group, ident, {
-                                name: ident,
-                                launch_configuration: launch_config,
-                                min_size: options[:instances][:min],
-                                max_size: options[:instances][:max],
-                                desired_capacity: options[:instances][:desired],
-                                vpc_zone_identifier: subnets.map(&:id),
-                                tags: {
-                                  Name: ident,
-                                  service_name: name,
-                                }.merge(options[:tags]).map { |k,v|
-                                  { key: k, value: v, propagate_at_launch: true }
-                                },
-                           }.merge(target_groups ? {target_group_arns: target_groups} : {})
-
-            @ids = [asg]
-          end
+          vpc.zone.add_alias_in(self, name, @load_balancer.alias_config)
 
         elsif options[:instances].is_a?(Array)
 
-          instance_ip = options[:public] ? :public_ip : :private_ip
+          @instance_set = add! StaticSet.create_in(
+                                 vpc, name, options.merge({
+                                   instance_profile: instance_profile,
+                                 }))
 
-          @instance_security_group = @access_security_group
-
-          @ids = options[:instances].map.with_index {|config, i|
-            instance_ident = "#{ident}-#{i}"
-
-            if config.has_key? :subnet and config.has_key? :ip_address
-              subnet = config[:subnet]
-              ip_address = config[:ip_address]
-              lifecycle = {
-                lifecycle: { create_before_destroy: false },
-              }
-            else
-              # pick something consistent but not just the first subnet
-              subnet_index = XXhash.xxh32(ident) % subnets.count
-              subnet = subnets[subnet_index]
-              lifecycle = {
-                lifecycle: { create_before_destroy: true },
-              }
-            end
-
-            instance_id = resource :aws_instance, instance_ident, {
-                                     ami: options[:ami],
-                                     instance_type: options[:instance_type],
-                                     iam_instance_profile: instance_profile,
-                                     subnet_id: subnet.id,
-                                     associate_public_ip_address: options[:public],
-                                     root_block_device: {
-                                       volume_type: 'gp2',
-                                       volume_size: 32,
-                                     },
-                                     tags: {
-                                       'Name' => "#{ident}-#{i}",
-                                     }.merge(options[:tags]),
-                                     vpc_security_group_ids: [
-                                       vpc.internal_ssh_security_group,
-                                       @instance_security_group,
-                                     ].push(*options[:security_groups]),
-                                     user_data: options[:user_data],
-                                     lifecycle: {
-                                       create_before_destroy: true,
-                                     },
-                                   }.merge(ip_address ? { private_ip: ip_address } : {}).merge(lifecycle)
-
-            options[:volumes].each.with_index { |volume, vol_i|
-              volume_name = "#{instance_ident}-#{vol_i}"
-              volume_id = resource :aws_ebs_volume, volume_name, {
-                                     availability_zone: subnet.az,
-                                     size: volume[:size],
-                                     type: volume.fetch(:type, "gp2"),
-                                     tags: {
-                                       Name: volume_name,
-                                     }.merge(options[:tags]),
-                                   }
-
-              resource :aws_volume_attachment, volume_name, {
-                         device_name: volume[:device],
-                         volume_id: volume_id,
-                         instance_id: instance_id,
-                         force_detach: true,
-                       }
-            }
-
-            @instance_fqdns.push(options[:zone].qualify("#{name}-#{i}"))
-            options[:zone].add_record_in(
-              self,
-              "#{name}-#{i}",
-              [output_of(:aws_instance, instance_ident, instance_ip)],
-            )
-
-            instance_id
-          }
-
-          options[:zone].add_record_in(
-            self,
-            name,
-            @ids.map.with_index {|_, i| output_of(:aws_instance, "#{ident}-#{i}", instance_ip) },
-          )
-
-          @ports.each { |port|
-            resource :aws_security_group_rule, "#{@name}-to-self-#{port[:name]}", {
-                       security_group_id: @instance_security_group,
-                       type: "ingress",
-                       from_port: port[:number],
-                       to_port: port[:number],
-                       protocol: port[:type],
-                       self: true,
-                     }
-
-            options[:zone].add_srv(
-              name, port[:name], port[:number], port[:type],
-              @ids.map.with_index { |_, i| "#{name}-#{i}" },
-            )
+          vpc.zone.add_record_in(self, name, @instance_set.instances.map { |i| i.ip_address })
+          @instance_set.instances.each { |i|
+            vpc.zone.add_record_in(self, i.name, [i.ip_address])
           }
 
         else
@@ -457,50 +98,20 @@ module Terrafying
         self
       end
 
-      def user_data(options={})
-        options = {
-          keypairs: [],
-          volumes: [],
-          units: [],
-          files: [],
-          ssh_group: @ssh_group,
-        }.merge(options)
-
-        options[:cas] = options[:keypairs].map { |kp| kp[:ca] }.sort.uniq
-
-        yaml = template("templates/service.yaml", options)
-
-        Terrafying::Util.to_ignition(yaml)
-      end
-
-      def used_by(other_service)
-        @ports.map {|port|
-          resource :aws_security_group_rule, "#{@name}-to-#{other_service.name}-#{port[:name]}", {
-                     security_group_id: port.fetch(:security_group, @access_security_group),
-                     type: "ingress",
-                     from_port: port[:number],
-                     to_port: port[:number],
-                     protocol: port[:type],
-                     source_security_group_id: other_service.instance_security_group,
-                   }
-        }
+      def used_by(*service)
+        if @load_balancer && @load_balancer.type == "application"
+          @load_balancer.used_by(*service)
+        else
+          @instance_set.used_by(*service)
+        end
       end
 
       def used_by_cidr(*cidrs)
-        cidrs.map { |cidr|
-          cidr_ident = cidr.gsub(/[\.\/]/, "-")
-
-          @ports.map {|port|
-            resource :aws_security_group_rule, "#{@name}-to-#{cidr_ident}-#{port[:name]}", {
-                       security_group_id: port.fetch(:security_group, @access_security_group),
-                       type: "ingress",
-                       from_port: port[:number],
-                       to_port: port[:number],
-                       protocol: port[:type],
-                       cidr_blocks: [cidr],
-                     }
-          }
-        }
+        if @load_balancer && @load_balancer.type == "application"
+          @load_balancer.used_by_cidr(*cidrs)
+        else
+          @instance_set.used_by_cidr(*cidrs)
+        end
       end
 
     end

--- a/lib/terrafying/components/staticset.rb
+++ b/lib/terrafying/components/staticset.rb
@@ -44,6 +44,7 @@ module Terrafying
           user_data: "",
           tags: {},
           ssh_group: vpc.ssh_group,
+          depends_on: [],
         }.merge(options)
 
         ident = "#{vpc.name}-#{name}"
@@ -92,6 +93,7 @@ module Terrafying
                                    security_groups: [@security_group] + options[:security_groups],
                                    ip_address: ip_address,
                                    lifecycle: lifecycle,
+                                   depends_on: options[:depends_on],
                                    tags: {
                                      staticset_name: ident,
                                    }.merge(options[:tags])

--- a/lib/terrafying/components/staticset.rb
+++ b/lib/terrafying/components/staticset.rb
@@ -1,0 +1,163 @@
+
+require 'xxhash'
+
+require_relative './ports'
+
+module Terrafying
+
+  module Components
+
+    class StaticSet < Terrafying::Context
+
+      attr_reader :name, :instances
+
+      def self.create_in(vpc, name, options={})
+        StaticSet.new.create_in vpc, name, options
+      end
+
+      def self.find_in(vpc, name)
+        StaticSet.new.find_in vpc, name
+      end
+
+      def initialize()
+        super
+      end
+
+      def find_in(vpc, name)
+        @name = name
+
+        raise 'unimplemented'
+
+        self
+      end
+
+      def create_in(vpc, name, options={})
+        options = {
+          public: false,
+          ami: aws.ami("CoreOS-stable-1576.4.0-hvm", owners=["595879546273"]),
+          instance_type: "t2.micro",
+          subnets: vpc.subnets.fetch(:private, []),
+          ports: [],
+          instances: [{}],
+          instance_profile: "",
+          security_groups: [],
+          user_data: "",
+          tags: {},
+          ssh_group: vpc.ssh_group,
+        }.merge(options)
+
+        ident = "#{vpc.name}-#{name}"
+
+        @name = ident
+        @ports = enrich_ports(options[:ports])
+
+        @security_group = resource :aws_security_group, ident, {
+                                     name: "staticset-#{ident}",
+                                     description: "Describe the ingress and egress of the static set #{ident}",
+                                     tags: options[:tags],
+                                     vpc_id: vpc.id,
+                                     egress: [
+                                       {
+                                         from_port: 0,
+                                         to_port: 0,
+                                         protocol: -1,
+                                         cidr_blocks: ["0.0.0.0/0"],
+                                       }
+                                     ],
+                                   }
+
+
+        @instances = options[:instances].map.with_index {|config, i|
+          instance_ident = "#{name}-#{i}"
+
+          if config.has_key? :subnet and config.has_key? :ip_address
+            subnet = config[:subnet]
+            ip_address = config[:ip_address]
+            lifecycle = {
+              lifecycle: { create_before_destroy: false },
+            }
+          else
+            # pick something consistent but not just the first subnet
+            subnet_index = XXhash.xxh32(ident) % options[:subnets].count
+            subnet = options[:subnets][subnet_index]
+            lifecycle = {
+              lifecycle: { create_before_destroy: true },
+            }
+          end
+
+          instance = add! Instance.create_in(
+                               vpc, instance_ident, options.merge(
+                                 {
+                                   subnet: subnet,
+                                   security_groups: [@security_group] + options[:security_groups],
+                                   ip_address: ip_address,
+                                   lifecycle: lifecycle,
+                                   tags: {
+                                     staticset_name: ident,
+                                   }.merge(options[:tags])
+                                 }
+                               )
+                             )
+
+          options[:volumes].each.with_index { |volume, vol_i|
+            volume_name = "#{instance_ident}-#{vol_i}"
+            volume_id = resource :aws_ebs_volume, volume_name, {
+                                   availability_zone: subnet.az,
+                                   size: volume[:size],
+                                   type: volume.fetch(:type, "gp2"),
+                                   tags: {
+                                     Name: volume_name,
+                                   }.merge(options[:tags]),
+                                 }
+
+            resource :aws_volume_attachment, volume_name, {
+                       device_name: volume[:device],
+                       volume_id: volume_id,
+                       instance_id: instance_id,
+                       force_detach: true,
+                     }
+          }
+
+          instance
+        }
+
+        @ports.each { |port|
+          resource :aws_security_group_rule, "#{@name}-to-self-#{port[:name]}", {
+                     security_group_id: @security_group,
+                     type: "ingress",
+                     from_port: port[:number],
+                     to_port: port[:number],
+                     protocol: port[:type],
+                     self: true,
+                   }
+        }
+
+        self
+      end
+
+      def used_by_cidr(*cidrs)
+        cidrs.map { |cidr|
+          cidr_ident = cidr.gsub(/[\.\/]/, "-")
+
+          @ports.map {|port|
+            resource :aws_security_group_rule, "#{@name}-to-#{cidr_ident}-#{port[:name]}", {
+                       security_group_id: port.fetch(:security_group, @security_group),
+                       type: "ingress",
+                       from_port: port[:number],
+                       to_port: port[:number],
+                       protocol: port[:type],
+                       cidr_blocks: [cidr],
+                     }
+          }
+        }
+      end
+
+      def used_by(*service)
+        raise 'unimplemented'
+      end
+
+    end
+
+  end
+
+end

--- a/lib/terrafying/components/staticset.rb
+++ b/lib/terrafying/components/staticset.rb
@@ -93,7 +93,7 @@ module Terrafying
           options[:volumes].each.with_index { |volume, vol_i|
             volume_name = "#{instance_ident}-#{vol_i}"
             volume_id = resource :aws_ebs_volume, volume_name, {
-                                   availability_zone: subnet.az,
+                                   availability_zone: instance.subnet.az,
                                    size: volume[:size],
                                    type: volume.fetch(:type, "gp2"),
                                    tags: {
@@ -104,7 +104,7 @@ module Terrafying
             resource :aws_volume_attachment, volume_name, {
                        device_name: volume[:device],
                        volume_id: volume_id,
-                       instance_id: instance_id,
+                       instance_id: instance.id,
                        force_detach: true,
                      }
           }

--- a/lib/terrafying/components/subnet.rb
+++ b/lib/terrafying/components/subnet.rb
@@ -75,7 +75,7 @@ module Terrafying
           gateway = { gateway_id: options[:gateway] }
           @public = true
         else
-          raise "You have to give a subnet either a nat or internet gateway"
+          @public = false
         end
 
         resource :aws_route, "#{name}-default", {

--- a/lib/terrafying/components/subnet.rb
+++ b/lib/terrafying/components/subnet.rb
@@ -75,13 +75,16 @@ module Terrafying
           gateway = { gateway_id: options[:gateway] }
           @public = true
         else
+          gateway = nil
           @public = false
         end
 
-        resource :aws_route, "#{name}-default", {
-                   route_table_id: @route_table,
-                   destination_cidr_block: "0.0.0.0/0",
-                 }.merge(gateway)
+        if gateway
+          resource :aws_route, "#{name}-default", {
+                     route_table_id: @route_table,
+                     destination_cidr_block: "0.0.0.0/0",
+                   }.merge(gateway)
+        end
 
         resource :aws_route_table_association, name, {
                    subnet_id: @id,

--- a/lib/terrafying/components/templates/ignition.yaml
+++ b/lib/terrafying/components/templates/ignition.yaml
@@ -69,7 +69,7 @@ systemd:
     <% units.each { |unit| %>
     - name: "<%= unit[:name] %>"
       enabled: true
-      contents: "<%= unit[:contents].gsub(/\n/, '\\n').gsub(/\"/, '\\"') %>"
+      contents: "<%= unit[:contents].dump[1..-2] %>"
     <% } %>
 
 

--- a/lib/terrafying/components/usable.rb
+++ b/lib/terrafying/components/usable.rb
@@ -1,0 +1,44 @@
+
+module Terrafying
+
+  module Components
+
+    module Usable
+
+      def used_by_cidr(*cidrs)
+        cidrs.map { |cidr|
+          cidr_ident = cidr.gsub(/[\.\/]/, "-")
+
+          @ports.map {|port|
+            resource :aws_security_group_rule, "#{@name}-to-#{cidr_ident}-#{port[:name]}", {
+                       security_group_id: @security_group,
+                       type: "ingress",
+                       from_port: port[:number],
+                       to_port: port[:number],
+                       protocol: port[:type],
+                       cidr_blocks: [cidr],
+                     }
+          }
+        }
+      end
+
+      def used_by(*other_resources)
+        other_resources.map { |other_resource|
+          @ports.map {|port|
+            resource :aws_security_group_rule, "#{@name}-to-#{other_resource.name}-#{port[:name]}", {
+                       security_group_id: @security_group,
+                       type: "ingress",
+                       from_port: port[:number],
+                       to_port: port[:number],
+                       protocol: port[:type],
+                       source_security_group_id: other_resource.security_group,
+                     }
+          }
+        }
+      end
+
+    end
+
+  end
+
+end

--- a/lib/terrafying/components/vpn.rb
+++ b/lib/terrafying/components/vpn.rb
@@ -42,6 +42,8 @@ module Terrafying
         options = {
           group: "uSwitch Developers",
           cidr: "10.8.0.0/24",
+          public: true,
+          subnets: vpc.subnets.fetch(:public, []),
           tags: {}
         }.merge(options)
 
@@ -109,10 +111,6 @@ module Terrafying
         end
 
         self
-      end
-
-      def instance_security_group
-        @service.instance_security_group
       end
 
       def used_by_cidr(*cidrs)

--- a/lib/terrafying/components/zone.rb
+++ b/lib/terrafying/components/zone.rb
@@ -86,8 +86,12 @@ module Terrafying
       end
 
       def add_alias(name, config)
+        add_alias_in(self, name, config)
+      end
+
+      def add_alias_in(ctx, name, config)
         fqdn = qualify(name)
-        resource :aws_route53_record, fqdn.gsub(/\./, "-"), {
+        ctx.resource :aws_route53_record, fqdn.gsub(/\./, "-"), {
                    zone_id: @id,
                    name: fqdn,
                    type: "A",

--- a/lib/terrafying/generator.rb
+++ b/lib/terrafying/generator.rb
@@ -79,9 +79,20 @@ module Terrafying
       ret
     end
 
-    def add!(c)
-      @children.push(c)
-      c
+    def resources
+      out = output_with_children
+      ret = []
+      for type in out["resource"].keys
+        for id in out["resource"][type].keys
+          ret << "${#{type}.#{id}.id}"
+        end
+      end
+      ret
+    end
+
+    def add!(*c)
+      @children.push(*c)
+      c[0]
     end
 
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,4 +99,5 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,8 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  Dir["./spec/support/**/*.rb"].each {|f| require f}
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin

--- a/spec/support/shared_examples/ca.rb
+++ b/spec/support/shared_examples/ca.rb
@@ -1,0 +1,96 @@
+shared_examples "a CA" do
+
+  it { is_expected.to respond_to(:create) }
+  it { is_expected.to respond_to(:create_keypair) }
+  it { is_expected.to respond_to(:create_keypair_in) }
+  it { is_expected.to respond_to(:reference_keypair) }
+  it { is_expected.to respond_to(:<=>) }
+
+  let :ca_name do
+    "some-ca"
+  end
+
+  let :bucket_name do
+    "a-bucket"
+  end
+
+  before do
+    @ca = described_class.create(ca_name, bucket_name)
+  end
+
+  describe ".create" do
+
+    it "should put the cert in s3" do
+      ca_cert = @ca.output["resource"]["aws_s3_bucket_object"].select { |_, obj|
+        obj[:key] == "/#{ca_name}/ca.cert" && obj[:bucket] == bucket_name
+      }
+
+      expect(ca_cert.count).to eq(1)
+      expect(@ca.source).to eq("s3://#{bucket_name}/#{ca_name}/ca.cert")
+    end
+
+    it "should populate name" do
+      expect(@ca.name).to eq(ca_name)
+    end
+
+  end
+
+  describe ".create_keypair_in" do
+
+    it "should put stuff in the right context" do
+      ctx = Terrafying::Context.new
+
+      keypair = @ca.create_keypair_in(ctx, "foo")
+
+      resource_names = keypair[:resources].map { |r| r.split(".")[1] }
+
+      expect(ctx.output["resource"]["aws_s3_bucket_object"].keys).to include(*resource_names)
+      expect(@ca.output["resource"]["aws_s3_bucket_object"].keys).to_not include(*resource_names)
+    end
+
+  end
+
+  describe ".create_keypair" do
+
+    it "should reference the right bucket objects in output" do
+      keypair = @ca.create_keypair("foo")
+
+      cert_object = @ca.output["resource"]["aws_s3_bucket_object"].select { |_, obj|
+        File.join("s3://", obj[:bucket], obj[:key]) == keypair[:source][:cert]
+      }.first
+      key_object = @ca.output["resource"]["aws_s3_bucket_object"].select { |_, obj|
+        File.join("s3://", obj[:bucket], obj[:key]) == keypair[:source][:key]
+      }.first
+
+      expect(cert_object).to_not be nil
+      expect(key_object).to_not be nil
+    end
+
+    it "should reference the correct resources in the IAM statement" do
+      keypair = @ca.create_keypair("foo")
+
+      objects = keypair[:iam_statement][:Resource].map { |arn|
+        path = arn.split(':::')[1]
+
+        _, obj = @ca.output["resource"]["aws_s3_bucket_object"].select { |_, obj|
+          File.join(obj[:bucket], obj[:key]) == path
+        }.first
+
+        obj
+      }
+
+      expect(objects).to all( be_a Hash )
+    end
+
+  end
+
+  it "should be sortable" do
+    a = described_class.create("a", "a-bucket")
+    b = described_class.create("b", "b-bucket")
+    c = described_class.create("c", "c-bucket")
+
+    unsorted = [b, c, a]
+    expect(unsorted.sort).to eq([a, b, c])
+  end
+
+end

--- a/spec/support/shared_examples/usable.rb
+++ b/spec/support/shared_examples/usable.rb
@@ -1,0 +1,80 @@
+shared_examples "a usable resource" do
+
+  it { is_expected.to respond_to(:used_by) }
+  it { is_expected.to respond_to(:used_by_cidr) }
+  it { is_expected.to respond_to(:security_group) }
+
+  let :ports do
+    [
+      { type: "http", number: 80 },
+      { type: "https", number: 443 },
+    ]
+  end
+
+  before do
+    aws_double = double("AWS")
+
+    allow(aws_double).to receive(:availability_zones).and_return([ "eu-west-1a", "eu-west-1b", "eu-west-1c" ])
+    allow(aws_double).to receive(:hosted_zone).and_return(Aws::Route53::Types::HostedZone.new)
+    allow(aws_double).to receive(:ami).and_return("ami-foobar")
+
+    allow_any_instance_of(Terrafying::Context).to receive(:aws).and_return(aws_double)
+
+    @vpc = Terrafying::Components::VPC.create("a-vpc", "10.0.0.0/16")
+    @main_resource = described_class.create_in(
+      @vpc, "some-thing", {
+        ports: ports,
+      },
+    )
+  end
+
+  it "should add ingress that maps the right cidrs" do
+    cidrs = ["10.1.0.0/16", "10.2.0.0/16"]
+    @main_resource.used_by_cidr(*cidrs)
+
+    output = @main_resource.output_with_children
+
+    expect(output["resource"]["aws_security_group_rule"].count).to be >= (ports.count * cidrs.count)
+
+    expect(
+      cidrs.product(ports).all? { |cidr, port|
+        output["resource"]["aws_security_group_rule"].any? { |_, rule|
+          rule[:type] == "ingress" && \
+          rule.has_key?(:cidr_blocks) && \
+          rule[:cidr_blocks][0] == cidr && \
+          rule[:from_port] == port[:number] && \
+          rule[:to_port] == port[:number] && \
+          rule[:protocol] == port[:type]
+        }
+      }
+    ).to be true
+
+  end
+
+  it "should add ingress that maps the right resources" do
+    other_resource = Terrafying::Components::Instance.create_in(@vpc, "some-thing-else")
+    another_resource = Terrafying::Components::Instance.create_in(@vpc, "another-thing")
+
+    resources = [other_resource, another_resource]
+
+    @main_resource.used_by(*resources)
+
+    output = @main_resource.output_with_children
+
+    expect(output["resource"]["aws_security_group_rule"].count).to be >= (ports.count * resources.count)
+
+    expect(
+      resources.product(ports).all? { |resource, port|
+        output["resource"]["aws_security_group_rule"].any? { |_, rule|
+          rule[:type] == "ingress" && \
+          rule.has_key?(:source_security_group_id) && \
+          rule[:source_security_group_id] == resource.security_group && \
+          rule[:from_port] == port[:number] && \
+          rule[:to_port] == port[:number] && \
+          rule[:protocol] == port[:type]
+        }
+      }
+    ).to be true
+  end
+
+end

--- a/spec/support/shared_examples/usable.rb
+++ b/spec/support/shared_examples/usable.rb
@@ -12,15 +12,7 @@ shared_examples "a usable resource" do
   end
 
   before do
-    aws_double = double("AWS")
-
-    allow(aws_double).to receive(:availability_zones).and_return([ "eu-west-1a", "eu-west-1b", "eu-west-1c" ])
-    allow(aws_double).to receive(:hosted_zone).and_return(Aws::Route53::Types::HostedZone.new)
-    allow(aws_double).to receive(:ami).and_return("ami-foobar")
-
-    allow_any_instance_of(Terrafying::Context).to receive(:aws).and_return(aws_double)
-
-    @vpc = Terrafying::Components::VPC.create("a-vpc", "10.0.0.0/16")
+    @vpc = stub_vpc("a-vpc", "10.0.0.0/15")
     @main_resource = described_class.create_in(
       @vpc, "some-thing", {
         ports: ports,

--- a/spec/support/vpc.rb
+++ b/spec/support/vpc.rb
@@ -1,0 +1,12 @@
+
+def stub_vpc(name, cidr, options={})
+  aws_double = double("AWS")
+
+  allow(aws_double).to receive(:availability_zones).and_return([ "eu-west-1a", "eu-west-1b", "eu-west-1c" ])
+  allow(aws_double).to receive(:hosted_zone).and_return(Aws::Route53::Types::HostedZone.new)
+  allow(aws_double).to receive(:ami).and_return("ami-foobar")
+
+  allow_any_instance_of(Terrafying::Context).to receive(:aws).and_return(aws_double)
+
+  Terrafying::Components::VPC.create(name, cidr, options)
+end

--- a/spec/terrafying/components/dynamicset_spec.rb
+++ b/spec/terrafying/components/dynamicset_spec.rb
@@ -1,0 +1,9 @@
+require 'terrafying'
+require 'terrafying/components/dynamicset'
+
+
+RSpec.describe Terrafying::Components::DynamicSet do
+
+  it_behaves_like "a usable resource"
+
+end

--- a/spec/terrafying/components/dynamicset_spec.rb
+++ b/spec/terrafying/components/dynamicset_spec.rb
@@ -6,4 +6,20 @@ RSpec.describe Terrafying::Components::DynamicSet do
 
   it_behaves_like "a usable resource"
 
+  before do
+    @vpc = stub_vpc("a-vpc", "10.0.0.0/16")
+  end
+
+  it "should just create a single asg by default" do
+    dynamic_set = Terrafying::Components::DynamicSet.create_in(@vpc, "foo")
+
+    expect(dynamic_set.output["resource"]["aws_autoscaling_group"].count).to eq(1)
+  end
+
+  it "should create an asg per availability zone when pivoting" do
+    dynamic_set = Terrafying::Components::DynamicSet.create_in(@vpc, "foo", { pivot: true })
+
+    expect(dynamic_set.output["resource"]["aws_autoscaling_group"].count).to eq(@vpc.azs.count)
+  end
+
 end

--- a/spec/terrafying/components/ignition_spec.rb
+++ b/spec/terrafying/components/ignition_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Terrafying::Components::Ignition, '#generate' do
   end
 
   it "setups keypairs/cas properly" do
-    ca = Terrafying::Components::CA.create("great-ca", "some-bucket")
+    ca = Terrafying::Components::SelfSignedCA.create("great-ca", "some-bucket")
     keypair = ca.create_keypair("foo")
 
     user_data = Terrafying::Components::Ignition.generate(

--- a/spec/terrafying/components/ignition_spec.rb
+++ b/spec/terrafying/components/ignition_spec.rb
@@ -1,15 +1,14 @@
 require 'terrafying'
-require 'terrafying/components/service'
+require 'terrafying/components/ignition'
 
-RSpec.describe Terrafying::Components::Service, '#user_data' do
+RSpec.describe Terrafying::Components::Ignition, '#generate' do
   context 'with volumes' do
     it 'creates userdata with correct mountpoints' do
       options = {
         volumes: [{ name: 'test_vol', mount: '/var/test', device: '/dev/test' }]
       }
-      service = Terrafying::Components::Service.new
 
-      user_data_ign = service.user_data(options)
+      user_data_ign = Terrafying::Components::Ignition.generate(options)
 
       units = JSON.parse(user_data_ign, { symbolize_names: true })[:systemd][:units]
 

--- a/spec/terrafying/components/ignition_spec.rb
+++ b/spec/terrafying/components/ignition_spec.rb
@@ -1,6 +1,70 @@
 require 'terrafying'
 require 'terrafying/components/ignition'
 
+
+RSpec.describe Terrafying::Components::Ignition, '#container_unit' do
+  it 'creates a unit file' do
+    container_unit = Terrafying::Components::Ignition.container_unit("app", "app:latest")
+
+    expect(container_unit[:name]).to eq("app.service")
+    expect(container_unit[:contents]).to match(/app:latest/)
+  end
+
+  it 'sets up host networking' do
+    container_unit = Terrafying::Components::Ignition.container_unit("app", "app:latest", { host_networking: true })
+
+    expect(container_unit[:contents]).to match(/--net=host/)
+  end
+
+  it 'sets up privileged mode' do
+    container_unit = Terrafying::Components::Ignition.container_unit("app", "app:latest", { privileged: true })
+
+    expect(container_unit[:contents]).to match(/--privileged/)
+  end
+
+  it 'adds environment variables' do
+    container_unit = Terrafying::Components::Ignition.container_unit(
+      "app", "app:latest", {
+        environment_variables: [ "FOO=bar" ],
+      }
+    )
+
+    expect(container_unit[:contents]).to match(/-e FOO=bar/)
+  end
+
+  it 'adds volumes' do
+    container_unit = Terrafying::Components::Ignition.container_unit(
+      "app", "app:latest", {
+        volumes: [ "/tmp:/tmp:ro" ],
+      }
+    )
+
+    expect(container_unit[:contents]).to match(/-v \/tmp:\/tmp:ro/)
+  end
+
+  it 'adds arguments' do
+    container_unit = Terrafying::Components::Ignition.container_unit(
+      "app", "app:latest", {
+        arguments: [ "/bin/bash", "-c 'echo hi'" ],
+      }
+    )
+
+    expect(container_unit[:contents]).to match(/\/bin\/bash\s+\\\n-c 'echo hi'/)
+  end
+
+  it 'adds required units' do
+    container_unit = Terrafying::Components::Ignition.container_unit(
+      "app", "app:latest", {
+        require_units: [ "disk.mount", "database.service" ],
+      }
+    )
+
+    expect(container_unit[:contents]).to match(/Requires=disk.mount database.service/)
+    expect(container_unit[:contents]).to match(/After=disk.mount database.service/)
+  end
+
+end
+
 RSpec.describe Terrafying::Components::Ignition, '#generate' do
   context 'with volumes' do
     it 'creates userdata with correct mountpoints' do
@@ -20,5 +84,74 @@ RSpec.describe Terrafying::Components::Ignition, '#generate' do
         }
       end).to be true
     end
+  end
+
+  it "adds in unit files" do
+    user_data = Terrafying::Components::Ignition.generate(
+      {
+        units: [{ name: "foo.service", contents: "LOOL" }],
+      }
+    )
+
+    units = JSON.parse(user_data, { symbolize_names: true })[:systemd][:units]
+
+    expect(units.any? do |unit|
+             unit == {
+               name: 'foo.service',
+               enabled: true,
+               contents: "LOOL"
+             }
+           end).to be true
+  end
+
+  it "adds in files" do
+    user_data = Terrafying::Components::Ignition.generate(
+      {
+        files: [{ path: "/etc/app/app.conf", mode: "0999", contents: "LOOL" }],
+      }
+    )
+
+    files = JSON.parse(user_data, { symbolize_names: true })[:storage][:files]
+
+    expect(files.any? do |file|
+             file == {
+               filesystem: "root",
+               mode: "0999",
+               path: "/etc/app/app.conf",
+               user: { id: 0 },
+               group: { id: 0 },
+               contents: { source: "data:;base64,TE9PTA==" },
+             }
+           end).to be true
+  end
+
+  it "passes through the ssh_group" do
+    user_data = Terrafying::Components::Ignition.generate(
+      {
+        ssh_group: "smurfs",
+      }
+    )
+
+    units = JSON.parse(user_data, { symbolize_names: true })[:systemd][:units]
+
+    usersync_unit = units.select { |u| u[:name] == "usersync.service" }.first
+
+    expect(usersync_unit[:contents]).to match(/-g="smurfs"/)
+  end
+
+  it "setups keypairs/cas properly" do
+    ca = Terrafying::Components::CA.create("great-ca", "some-bucket")
+    keypair = ca.create_keypair("foo")
+
+    user_data = Terrafying::Components::Ignition.generate(
+      {
+        keypairs: [ keypair ],
+      }
+    )
+
+    files = JSON.parse(user_data, { symbolize_names: true })[:storage][:files]
+    paths = files.map { |f| f[:path] }
+
+    expect(paths).to include("/etc/ssl/great-ca/ca.cert", "/etc/ssl/great-ca/foo/key", "/etc/ssl/great-ca/foo/cert")
   end
 end

--- a/spec/terrafying/components/instance_spec.rb
+++ b/spec/terrafying/components/instance_spec.rb
@@ -1,0 +1,9 @@
+require 'terrafying'
+require 'terrafying/components/instance'
+
+
+RSpec.describe Terrafying::Components::Instance do
+
+  it_behaves_like "a usable resource"
+
+end

--- a/spec/terrafying/components/instance_spec.rb
+++ b/spec/terrafying/components/instance_spec.rb
@@ -7,15 +7,7 @@ RSpec.describe Terrafying::Components::Instance do
   it_behaves_like "a usable resource"
 
   before do
-    aws_double = double("AWS")
-
-    allow(aws_double).to receive(:availability_zones).and_return([ "eu-west-1a", "eu-west-1b", "eu-west-1c" ])
-    allow(aws_double).to receive(:hosted_zone).and_return(Aws::Route53::Types::HostedZone.new)
-    allow(aws_double).to receive(:ami).and_return("ami-foobar")
-
-    allow_any_instance_of(Terrafying::Context).to receive(:aws).and_return(aws_double)
-
-    @vpc = Terrafying::Components::VPC.create("a-vpc", "10.0.0.0/16")
+    @vpc = stub_vpc("a-vpc", "10.0.0.0/16")
   end
 
   it "should destroy then create when an ip is defined" do

--- a/spec/terrafying/components/instance_spec.rb
+++ b/spec/terrafying/components/instance_spec.rb
@@ -6,4 +6,37 @@ RSpec.describe Terrafying::Components::Instance do
 
   it_behaves_like "a usable resource"
 
+  before do
+    aws_double = double("AWS")
+
+    allow(aws_double).to receive(:availability_zones).and_return([ "eu-west-1a", "eu-west-1b", "eu-west-1c" ])
+    allow(aws_double).to receive(:hosted_zone).and_return(Aws::Route53::Types::HostedZone.new)
+    allow(aws_double).to receive(:ami).and_return("ami-foobar")
+
+    allow_any_instance_of(Terrafying::Context).to receive(:aws).and_return(aws_double)
+
+    @vpc = Terrafying::Components::VPC.create("a-vpc", "10.0.0.0/16")
+  end
+
+  it "should destroy then create when an ip is defined" do
+    instance = Terrafying::Components::Instance.create_in(
+      @vpc, "an-instance", { ip_address: "10.0.0.5" }
+    )
+
+    expect(instance.output["resource"]["aws_instance"].values.first[:lifecycle][:create_before_destroy]).to be false
+  end
+
+  it "should pick a subnet for you if given a list" do
+    instance = Terrafying::Components::Instance.create_in(
+      @vpc, "an-instance", {
+        subnets: @vpc.subnets[:private],
+      }
+    )
+
+    subnet_id = instance.output["resource"]["aws_instance"].values.first[:subnet_id]
+
+    expect(@vpc.subnets[:private].map{|s| s.id}).to include(subnet_id)
+
+  end
+
 end

--- a/spec/terrafying/components/letsencrypt_spec.rb
+++ b/spec/terrafying/components/letsencrypt_spec.rb
@@ -1,0 +1,9 @@
+require 'terrafying'
+require 'terrafying/components/letsencrypt'
+
+
+RSpec.describe Terrafying::Components::LetsEncrypt do
+
+  it_behaves_like "a CA"
+
+end

--- a/spec/terrafying/components/loadbalancer_spec.rb
+++ b/spec/terrafying/components/loadbalancer_spec.rb
@@ -6,4 +6,62 @@ RSpec.describe Terrafying::Components::LoadBalancer do
 
   it_behaves_like "a usable resource"
 
+  before do
+    @vpc = stub_vpc("a-vpc", "10.0.0.0/16")
+  end
+
+  it "should error on a mix of layer 4 and 7 ports" do
+    expect {
+      Terrafying::Components::LoadBalancer.create_in(
+        @vpc, "foo", {
+          ports: [
+            { type: "tcp", number: 1234 },
+            { type: "https", number: 443 },
+          ],
+        }
+      )
+    }.to raise_error RuntimeError
+  end
+
+  it "should create an ALB when only layer 7" do
+    lb = Terrafying::Components::LoadBalancer.create_in(
+      @vpc, "foo", {
+        ports: [
+          { type: "https", number: 443 },
+        ],
+      }
+    )
+
+    expect(lb.type).to eq("application")
+  end
+
+  it "should create an NLB when only layer 4" do
+    lb = Terrafying::Components::LoadBalancer.create_in(
+      @vpc, "foo", {
+        ports: [
+          { type: "tcp", number: 1234 },
+        ],
+      }
+    )
+
+    expect(lb.type).to eq("network")
+  end
+
+  it "if a port defines a ssl cert it should be added to the listener" do
+    lb = Terrafying::Components::LoadBalancer.create_in(
+      @vpc, "foo", {
+        ports: [
+          { type: "https", number: 443, ssl_certificate: "some-arn" },
+        ],
+      }
+    )
+
+    expect(lb.output["resource"]["aws_lb_listener"].count).to eq(1)
+
+    listener = lb.output["resource"]["aws_lb_listener"].values.first
+
+    expect(listener[:ssl_policy]).to_not be nil
+    expect(listener[:certificate_arn]).to eq("some-arn")
+  end
+
 end

--- a/spec/terrafying/components/loadbalancer_spec.rb
+++ b/spec/terrafying/components/loadbalancer_spec.rb
@@ -1,0 +1,9 @@
+require 'terrafying'
+require 'terrafying/components/loadbalancer'
+
+
+RSpec.describe Terrafying::Components::LoadBalancer do
+
+  it_behaves_like "a usable resource"
+
+end

--- a/spec/terrafying/components/selfsignedca_spec.rb
+++ b/spec/terrafying/components/selfsignedca_spec.rb
@@ -1,0 +1,9 @@
+require 'terrafying'
+require 'terrafying/components/selfsignedca'
+
+
+RSpec.describe Terrafying::Components::SelfSignedCA do
+
+  it_behaves_like "a CA"
+
+end

--- a/spec/terrafying/components/service_spec.rb
+++ b/spec/terrafying/components/service_spec.rb
@@ -6,4 +6,85 @@ RSpec.describe Terrafying::Components::Service do
 
   it_behaves_like "a usable resource"
 
+  before do
+    @vpc = stub_vpc("a-vpc", "10.0.0.0/16")
+  end
+
+  it "should use user_data if passed in" do
+    user_data = "something"
+    service = Terrafying::Components::Service.create_in(
+      @vpc, "foo", {
+        user_data: user_data,
+      }
+    )
+
+    output = service.output_with_children
+
+    expect(output["resource"]["aws_instance"].values.first[:user_data]).to eq(user_data)
+  end
+
+  it "should generate user_data if not explicitly given" do
+    unit = Terrafying::Components::Ignition.container_unit("app", "app:latest")
+    service = Terrafying::Components::Service.create_in(
+      @vpc, "foo", {
+        units: [unit],
+      }
+    )
+
+    output = service.output_with_children
+
+    unit_contents = unit[:contents].dump[1..-2]
+
+    expect(output["resource"]["aws_instance"].values.first[:user_data]).to include(unit_contents)
+  end
+
+  it "should depend on any key pairs passed in" do
+    ca = Terrafying::Components::SelfSignedCA.create("ca", "some-bucket")
+    keypair = ca.create_keypair("keys")
+
+    service = Terrafying::Components::Service.create_in(
+      @vpc, "foo", {
+        keypairs: [keypair],
+      }
+    )
+
+    output = service.output_with_children
+
+    expect(output["resource"]["aws_instance"].values.first[:depends_on]).to include(*keypair[:resources])
+  end
+
+  it "should create a dynamic set when instances is a hash" do
+    service = Terrafying::Components::Service.create_in(
+      @vpc, "foo", {
+        instances: { min: 1, max: 1, desired: 1 },
+      }
+    )
+
+    output = service.output_with_children
+
+    expect(output["resource"]["aws_autoscaling_group"].count).to eq(1)
+  end
+
+  it "should create a static set when instances is an array" do
+    service = Terrafying::Components::Service.create_in(
+      @vpc, "foo", {
+        instances: [{}, {}],
+      }
+    )
+
+    output = service.output_with_children
+
+    expect(output["resource"]["aws_instance"].count).to eq(2)
+  end
+
+  it "should error when instances is something unknown" do
+    expect {
+      Terrafying::Components::Service.create_in(
+        @vpc, "foo", {
+          instances: 3,
+        }
+      )
+    }.to raise_error RuntimeError
+  end
+
 end

--- a/spec/terrafying/components/service_spec.rb
+++ b/spec/terrafying/components/service_spec.rb
@@ -1,0 +1,9 @@
+require 'terrafying'
+require 'terrafying/components/service'
+
+
+RSpec.describe Terrafying::Components::Service do
+
+  it_behaves_like "a usable resource"
+
+end

--- a/spec/terrafying/components/staticset_spec.rb
+++ b/spec/terrafying/components/staticset_spec.rb
@@ -6,4 +6,53 @@ RSpec.describe Terrafying::Components::StaticSet do
 
   it_behaves_like "a usable resource"
 
+  before do
+    @vpc = stub_vpc("a-vpc", "10.0.0.0/16")
+  end
+
+  it "should create the correct number of instances" do
+    instances = [{}, {}, {}]
+    set = Terrafying::Components::StaticSet.create_in(
+      @vpc, "foo", {
+        instances: instances,
+      }
+    )
+
+    output = set.output_with_children
+
+    expect(output["resource"]["aws_instance"].count).to eq(instances.count)
+  end
+
+  it "should create volumes for each instance based on spec" do
+    instances = [{}, {}]
+    volumes = [
+      {
+        size: 100,
+        device: "/dev/xvdl",
+        mount: "/mnt/data",
+      },
+    ]
+
+    set = Terrafying::Components::StaticSet.create_in(
+      @vpc, "foo", { instances: instances, volumes: volumes },
+    )
+
+    output = set.output_with_children
+
+    expect(output["resource"]["aws_ebs_volume"].count).to eq(instances.count * volumes.count)
+    expect(output["resource"]["aws_volume_attachment"].count).to eq(instances.count * volumes.count)
+  end
+
+  it "should setup security group rules for instances to talk to each other on" do
+    ports = [80, 443]
+    set = Terrafying::Components::StaticSet.create_in(
+      @vpc, "foo", { ports: ports }
+    )
+
+    output = set.output_with_children
+
+    expect(output["resource"]["aws_security_group_rule"].count).to eq(ports.count)
+    expect(output["resource"]["aws_security_group_rule"].values.all? {|r| r[:self]}).to be true
+  end
+
 end

--- a/spec/terrafying/components/staticset_spec.rb
+++ b/spec/terrafying/components/staticset_spec.rb
@@ -1,0 +1,9 @@
+require 'terrafying'
+require 'terrafying/components/staticset'
+
+
+RSpec.describe Terrafying::Components::StaticSet do
+
+  it_behaves_like "a usable resource"
+
+end

--- a/spec/terrafying/components/vpc_spec.rb
+++ b/spec/terrafying/components/vpc_spec.rb
@@ -1,0 +1,219 @@
+require 'terrafying'
+require 'terrafying/components/staticset'
+
+
+RSpec.describe Terrafying::Components::VPC do
+
+  before do
+    @aws = double("AWS")
+
+    @azs = [ "eu-west-1a", "eu-west-1b", "eu-west-1c" ]
+
+    allow(@aws).to receive(:availability_zones).and_return(@azs)
+    allow(@aws).to receive(:hosted_zone).and_return(Aws::Route53::Types::HostedZone.new)
+    allow(@aws).to receive(:ami).and_return("ami-foobar")
+
+    allow_any_instance_of(Terrafying::Context).to receive(:aws).and_return(@aws)
+  end
+
+  context "parent_zone" do
+    it "should default zone if not defined" do
+      Terrafying::Components::VPC.create("foo", "10.0.0.0/16")
+
+      expect(@aws).to have_received(:hosted_zone).with(Terrafying::Components::DEFAULT_ZONE)
+    end
+
+    it "should use provided zone" do
+      zone = Terrafying::Components::Zone.create("blah.usw.co")
+      Terrafying::Components::VPC.create("foo", "10.0.0.0/16", { parent_zone: zone })
+
+      expect(@aws).to_not have_received(:hosted_zone)
+    end
+  end
+
+  context "subnets" do
+
+    it "should create public and private when internet accesible" do
+      vpc = Terrafying::Components::VPC.create("foo", "10.0.0.0/16", { internet_access: true })
+
+      expect(vpc.subnets[:private].count).to eq(@azs.count)
+      expect(vpc.subnets[:public].count).to eq(@azs.count)
+    end
+
+    it "should create only private when not internet accesible" do
+      vpc = Terrafying::Components::VPC.create("foo", "10.0.0.0/16", { internet_access: false })
+
+      expect(vpc.subnets[:private].count).to eq(@azs.count)
+      expect(vpc.subnets.has_key?(:public)).to be false
+    end
+
+    it "should raise an error if there isn't enough room for the required subnets" do
+      expect {
+        Terrafying::Components::VPC.create("foo", "10.0.0.0/24")
+      }.to raise_error(RuntimeError)
+    end
+
+    it "should create nat gateway public networks when internet accessible" do
+      vpc = Terrafying::Components::VPC.create("foo", "10.0.0.0/16", { internet_access: true })
+
+      expect(vpc.subnets[:nat_gateway].count).to eq(@azs.count)
+    end
+
+    it "should be able to be overriden by options" do
+      vpc = Terrafying::Components::VPC.create(
+        "foo", "10.0.0.0/16", {
+          subnets: {
+            dmz: { public: true },
+            secure: { public: false, internet: false },
+          },
+        }
+      )
+
+      expect(vpc.subnets.has_key?(:public)).to be false
+      expect(vpc.subnets.has_key?(:private)).to be false
+      expect(vpc.subnets[:dmz].count).to eq(@azs.count)
+      expect(vpc.subnets[:secure].count).to eq(@azs.count)
+    end
+
+  end
+
+  it "should create a security group for SSH around the VPC" do
+    cidr = "10.1.0.0/16"
+    vpc = Terrafying::Components::VPC.create("foo", cidr)
+
+    expect(vpc.output["resource"]["aws_security_group"].count).to eq(1)
+
+    ssh_security_group = vpc.output["resource"]["aws_security_group"].values.first
+
+    expect(ssh_security_group[:ingress].count).to eq(1)
+    expect(ssh_security_group[:egress].count).to eq(1)
+
+    rule = {
+      from_port: 22,
+      to_port: 22,
+      protocol: "tcp",
+      cidr_blocks: [cidr],
+    }
+
+    expect(ssh_security_group[:ingress][0]).to eq(rule)
+    expect(ssh_security_group[:egress][0]).to eq(rule)
+  end
+
+  context "peer_with" do
+
+    it "should raise an error if the cidrs are overlapping" do
+      vpc_a = Terrafying::Components::VPC.create("a", "10.0.0.0/16")
+      vpc_b = Terrafying::Components::VPC.create("b", "10.0.0.0/20")
+
+      expect {
+        vpc_a.peer_with(vpc_b)
+      }.to raise_error(RuntimeError)
+    end
+
+    it "should create routes in both VPCs" do
+      vpc_a = Terrafying::Components::VPC.create("a", "10.0.0.0/16")
+      vpc_b = Terrafying::Components::VPC.create("b", "10.1.0.0/16")
+
+      original_route_count = vpc_a.output_with_children["resource"]["aws_route"].count
+
+      vpc_a.peer_with(vpc_b)
+
+      num_new_routes = vpc_a.output_with_children["resource"]["aws_route"].count - original_route_count
+
+      expect(num_new_routes).to eq(vpc_a.subnets.count * vpc_a.azs.count + vpc_b.subnets.count * vpc_b.azs.count)
+    end
+
+    it "should allow users to limit the subnets that are peered" do
+      vpc_a = Terrafying::Components::VPC.create("a", "10.0.0.0/16")
+      vpc_b = Terrafying::Components::VPC.create("b", "10.1.0.0/16")
+
+      original_route_count = vpc_a.output_with_children["resource"]["aws_route"].count
+
+      our_subnets = vpc_a.subnets[:public]
+      their_subnets = vpc_b.subnets[:public]
+
+      vpc_a.peer_with(vpc_b, { our_subnets: our_subnets, their_subnets: their_subnets })
+
+      num_new_routes = vpc_a.output_with_children["resource"]["aws_route"].count - original_route_count
+
+      expect(num_new_routes).to eq(our_subnets.count + their_subnets.count)
+    end
+
+  end
+
+  context "extract_subnet!" do
+
+    it "should limit the size of a subnet to a /28" do
+      vpc = Terrafying::Components::VPC.create("foo", "10.0.0.0/16")
+      cidr = vpc.extract_subnet!(30)
+
+      expect(cidr).to match(/[\.0-9]+\/28/)
+    end
+
+    it "should raise when there are no subnets left" do
+      vpc = Terrafying::Components::VPC.create("foo", "10.0.0.0/16")
+
+      249.times {
+        vpc.extract_subnet!(24)
+      }
+
+      expect {
+        vpc.extract_subnet!(24)
+      }.to raise_error(RuntimeError)
+    end
+
+  end
+
+  context "allocate_subnet!" do
+
+    it "should create subnets for each availability zone" do
+      vpc = Terrafying::Components::VPC.create("foo", "10.0.0.0/16")
+      subnets = vpc.allocate_subnets!("asdf")
+
+      expect(subnets.count).to eq(vpc.azs.count)
+    end
+
+    it "should attach an internet gateway if subnet is public" do
+      vpc = Terrafying::Components::VPC.create("foo", "10.0.0.0/16")
+      subnets = vpc.allocate_subnets!("asdf", { public: true })
+
+      output = vpc.output_with_children
+
+      route = output["resource"]["aws_route"].values.select { |route|
+        route[:route_table_id] = subnets[0].route_table
+      }.first
+
+      expect(route.has_key?(:gateway_id)).to be true
+      expect(route.has_key?(:nat_gateway_id)).to be false
+    end
+
+    it "should attach a NAT gateway if it's connected to the internet but not public" do
+      vpc = Terrafying::Components::VPC.create("foo", "10.0.0.0/16")
+      subnets = vpc.allocate_subnets!("asdf", { public: false, internet: true })
+
+      output = vpc.output_with_children
+
+      route = output["resource"]["aws_route"].values.select { |route|
+        route[:route_table_id] == subnets[0].route_table
+      }.first
+
+      expect(route.has_key?(:gateway_id)).to be false
+      expect(route.has_key?(:nat_gateway_id)).to be true
+    end
+
+    it "should not have any routes if it isn't public and no internet" do
+      vpc = Terrafying::Components::VPC.create("foo", "10.0.0.0/16")
+      subnets = vpc.allocate_subnets!("asdf", { public: false, internet: false })
+
+      output = vpc.output_with_children
+
+      routes = output["resource"]["aws_route"].values.select { |route|
+        route[:route_table_id] == subnets[0].route_table
+      }
+
+      expect(routes.count).to eq(0)
+    end
+
+  end
+
+end

--- a/terrafying.gemspec
+++ b/terrafying.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency 'rspec', '~> 3.7'
+  spec.add_development_dependency 'rspec-mocks', '~> 3.7'
 
   spec.add_runtime_dependency 'aws-sdk', '~> 2'
   spec.add_runtime_dependency 'thor', '~> 0.19.1'


### PR DESCRIPTION
## Optional auth for VPN

When playing around with Terrafying it is a pain in the rear to have to add auth to the VPN. This let's us choose to opt in or out of authentication. Also adds a potential extension for other providers.

```
vpn = Terrafying::Components::VPN.create_in(
  vpc, "vpn", {
    oauth2_provider: {
      type: "azure",
      client_id: "...",
      client_secret: "...",
      tenant_id: "...",
      permit_groups: ["kubernetes-supers"],
      register: true,    # whether it should add the VPN to list of reply urls on application
    }
  }
)
```

## Broken up Service into components

I split it up into StaticSet (a set of machines that has a static size and config), DynamicSet (a set of machines driven by an ASG), LoadBalancer (will select either an ALB or NLB depending on ports (L7 or L4), InstanceProfile and Instance.

This should make Service stop being quite the ball of string it was turning into.

It provides the same interface as it used to.

## LetsEncrypt CA component

Previously the VPN retrieved its own LetsEncrypt cert when it booted up for the first time. We started hitting rate limits as every time we tore the machines down it would re-request the cert. Rather than attaching an EBS volume or something to persist the certs I thought it would be easier to use the ACME provider for terraform to get the certs and persist them into the state file.

This requires the user of terraform to have https://github.com/paybyphone/terraform-provider-acme setup locally. I have bundled it into the docker image 

## Depending on resources before creating a Service/StaticSet/DynamicSet

Sometimes we don't want to create instances before other Terraform resources have been created. This lets you add a list of resources for the instances to depend on and ensures that any depedent key pairs have been created before instances come up.