### PR TITLE
Make sure we depend on the ca cert when needed

### DIFF
--- a/lib/terrafying/components/ca.rb
+++ b/lib/terrafying/components/ca.rb
@@ -9,17 +9,20 @@ module Terrafying
         create_keypair_in(self, name, options)
       end
 
-      def reference_keypair(name)
+      def reference_keypair(ctx, name)
         key_ident = "#{@name}-#{name.gsub(/\./, '-')}"
 
-        {
+        ref = {
           name: name,
           ca: self,
           source: {
             cert: File.join("s3://", @bucket, @prefix, @name, name, "cert"),
             key: File.join("s3://", @bucket, @prefix, @name, name, "key"),
           },
-          resources: [ "aws_s3_bucket_object.#{key_ident}-key", "aws_s3_bucket_object.#{key_ident}-cert" ],
+          resources: [
+            "aws_s3_bucket_object.#{key_ident}-key",
+            "aws_s3_bucket_object.#{key_ident}-cert"
+          ],
           iam_statement: {
             Effect: "Allow",
             Action: [
@@ -33,6 +36,12 @@ module Terrafying
             ]
           }
         }
+
+        if self == ctx
+          ref[:resources] << "aws_s3_bucket_object.#{@name}-cert"
+        end
+
+        ref
       end
 
       def <=>(other)

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -54,7 +54,7 @@ module Terrafying
         resource :aws_s3_bucket_object, "#{@name}-cert", {
                    bucket: @bucket,
                    key: File.join(@prefix, @name, "ca.cert"),
-                   content: "",
+                   content: "we don't care as it's trusted, just want parity",
                  }
 
         @source = File.join("s3://", @bucket, @prefix, @name, "ca.cert")
@@ -116,7 +116,7 @@ module Terrafying
                        content: output_of(:acme_certificate, key_ident, :certificate_pem),
                      }
 
-        reference_keypair(name)
+        reference_keypair(ctx, name)
       end
 
     end

--- a/lib/terrafying/components/selfsignedca.rb
+++ b/lib/terrafying/components/selfsignedca.rb
@@ -53,7 +53,7 @@ module Terrafying
                    ],
                  }
 
-        resource :aws_s3_bucket_object, "#{@ident}-cert", {
+        resource :aws_s3_bucket_object, "#{@name}-cert", {
                    bucket: @bucket,
                    key: File.join(@prefix, @name, "ca.cert"),
                    content: output_of(:tls_self_signed_cert, @ident, :cert_pem),
@@ -121,7 +121,7 @@ module Terrafying
                        content: output_of(:tls_locally_signed_cert, key_ident, :cert_pem),
                      }
 
-        reference_keypair(name)
+        reference_keypair(ctx, name)
       end
 
     end

--- a/spec/support/shared_examples/ca.rb
+++ b/spec/support/shared_examples/ca.rb
@@ -82,6 +82,15 @@ shared_examples "a CA" do
       expect(objects).to all( be_a Hash )
     end
 
+    it "should reference resources that exist" do
+      keypair = @ca.create_keypair("foo")
+
+      expect(keypair[:resources].all? { |r|
+        type, name = r.split(".")
+        @ca.output["resource"][type].has_key? name
+      }).to be true
+    end
+
   end
 
   it "should be sortable" do


### PR DESCRIPTION
If we are creating a CA cert in the same run as creating
a service, it should also wait for the CA cert to exist before
letting the machine spin up