### PR TITLE
Add tf_safe function to remove bad chars

### DIFF
--- a/lib/terrafying/components/ca.rb
+++ b/lib/terrafying/components/ca.rb
@@ -10,7 +10,7 @@ module Terrafying
       end
 
       def reference_keypair(ctx, name)
-        key_ident = "#{@name}-#{name.gsub(/\./, '-')}"
+        key_ident = "#{@name}-#{tf_safe(name)}"
 
         ref = {
           name: name,

--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -47,7 +47,7 @@ module Terrafying
           depends_on: [],
         }.merge(options)
 
-        ident = "#{vpc.name}-#{name}"
+        ident = "#{tf_safe(vpc.name)}-#{name}"
 
         @name = ident
         @ports = enrich_ports(options[:ports])

--- a/lib/terrafying/components/endpoint.rb
+++ b/lib/terrafying/components/endpoint.rb
@@ -30,7 +30,7 @@ module Terrafying
           tags: {},
         }.merge(options)
 
-        ident = "#{vpc.name}-#{name}"
+        ident = "#{tf_safe(vpc.name)}-#{name}"
         @name = name
 
         if options[:service]

--- a/lib/terrafying/components/instance.rb
+++ b/lib/terrafying/components/instance.rb
@@ -38,7 +38,7 @@ module Terrafying
           depends_on: [],
         }.merge(options)
 
-        ident = "#{vpc.name}-#{name}"
+        ident = "#{tf_safe(vpc.name)}-#{name}"
 
         @name = name
         @ports = enrich_ports(options[:ports])

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -76,7 +76,7 @@ module Terrafying
           ip_addresses: [],
         }.merge(options)
 
-        key_ident = "#{@name}-#{name.gsub(/\./, '-')}"
+        key_ident = "#{@name}-#{tf_safe(name)}"
 
         ctx.resource :tls_private_key, key_ident, {
                        algorithm: "ECDSA",

--- a/lib/terrafying/components/loadbalancer.rb
+++ b/lib/terrafying/components/loadbalancer.rb
@@ -27,13 +27,13 @@ module Terrafying
       end
 
       def find_in(vpc, name)
-        ident = "network-#{vpc.name}-#{name}"
+        ident = "network-#{tf_safe(vpc.name)}-#{name}"
         @type = "network"
 
         begin
           lb = aws.lb_by_name(ident)
         rescue
-          ident = "application-#{vpc.name}-#{name}"
+          ident = "application-#{tf_safe(vpc.name)}-#{name}"
           @type = "application"
 
           lb = aws.lb_by_name(ident)
@@ -76,7 +76,7 @@ module Terrafying
 
         @type = l4_ports.count == 0 ? "application" : "network"
 
-        ident = "#{type}-#{vpc.name}-#{name}"
+        ident = "#{type}-#{tf_safe(vpc.name)}-#{name}"
         @name = ident
 
         if @type == "application"

--- a/lib/terrafying/components/selfsignedca.rb
+++ b/lib/terrafying/components/selfsignedca.rb
@@ -82,7 +82,7 @@ module Terrafying
           ip_addresses: [],
         }.merge(options)
 
-        key_ident = "#{@name}-#{name.gsub(/\./, '-')}"
+        key_ident = "#{@name}-#{tf_safe(name)}"
 
         ctx.resource :tls_private_key, key_ident, {
                        algorithm: "ECDSA",

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -69,7 +69,7 @@ module Terrafying
           raise 'Unknown instances option, should be hash or array'
         end
 
-        ident = "#{vpc.name}-#{name}"
+        ident = "#{tf_safe(vpc.name)}-#{name}"
 
         @name = ident
         @ports = enrich_ports(options[:ports])

--- a/lib/terrafying/components/staticset.rb
+++ b/lib/terrafying/components/staticset.rb
@@ -52,7 +52,7 @@ module Terrafying
           volumes: [],
         }.merge(options)
 
-        ident = "#{vpc.name}-#{name}"
+        ident = "#{tf_safe(vpc.name)}-#{name}"
 
         @name = ident
         @ports = enrich_ports(options[:ports])

--- a/lib/terrafying/components/subnet.rb
+++ b/lib/terrafying/components/subnet.rb
@@ -50,20 +50,20 @@ module Terrafying
           tags: {},
         }.merge(options)
 
-        name = "#{vpc.name}-#{name}-#{az}"
+        ident = "#{tf_safe(vpc.name)}-#{name}-#{az}"
 
         @cidr = cidr
         @az = az
-        @id = resource :aws_subnet, name, {
+        @id = resource :aws_subnet, ident, {
                          vpc_id: vpc.id,
                          cidr_block: cidr,
                          availability_zone: az,
-                         tags: { Name: name }.merge(options[:tags]),
+                         tags: { Name: ident }.merge(options[:tags]),
                        }
 
-        @route_table = resource :aws_route_table, name, {
+        @route_table = resource :aws_route_table, ident, {
                                   vpc_id: vpc.id,
-                                  tags: { Name: name }.merge(options[:tags]),
+                                  tags: { Name: ident }.merge(options[:tags]),
                                 }
 
 
@@ -80,13 +80,13 @@ module Terrafying
         end
 
         if gateway
-          resource :aws_route, "#{name}-default", {
+          resource :aws_route, "#{ident}-default", {
                      route_table_id: @route_table,
                      destination_cidr_block: "0.0.0.0/0",
                    }.merge(gateway)
         end
 
-        resource :aws_route_table_association, name, {
+        resource :aws_route_table_association, ident, {
                    subnet_id: @id,
                    route_table_id: @route_table,
                  }

--- a/lib/terrafying/components/vpc.rb
+++ b/lib/terrafying/components/vpc.rb
@@ -68,7 +68,7 @@ module Terrafying
           @ssh_group = DEFAULT_SSH_GROUP
         end
 
-        @internal_ssh_security_group = aws.security_group("#{name.gsub(/[\s\.]/,"-")}-internal-ssh")
+        @internal_ssh_security_group = aws.security_group("#{tf_safe(name)}-internal-ssh")
         self
       end
 
@@ -205,7 +205,7 @@ module Terrafying
           ],
         }.merge(options)
 
-        other_vpc_ident = other_vpc.name.gsub(/[\s\.]/, "-")
+        other_vpc_ident = tf_safe(other_vpc.name)
 
         our_cidr = NetAddr::CIDR.create(@cidr)
         other_cidr = NetAddr::CIDR.create(other_vpc.cidr)
@@ -226,7 +226,7 @@ module Terrafying
 
           route_tables.product(cidrs).each { |route_table, cidr|
 
-            hash = Digest::SHA2.hexdigest "#{route_table}-#{cidr.gsub(/[\.\/]/, "-")}"
+            hash = Digest::SHA2.hexdigest "#{route_table}-#{tf_safe(cidr)}"
 
             resource :aws_route, "#{@name}-#{other_vpc_ident}-peer-#{hash}", {
                        route_table_id: route_table,

--- a/lib/terrafying/components/zone.rb
+++ b/lib/terrafying/components/zone.rb
@@ -47,7 +47,7 @@ module Terrafying
           tags: {},
         }.merge(options)
 
-        ident = fqdn.gsub(/\./, "-")
+        ident = tf_safe(fqdn)
 
         @fqdn = fqdn
         @id = resource :aws_route53_zone, ident, {
@@ -76,7 +76,7 @@ module Terrafying
 
       def add_record_in(ctx, name,records)
         fqdn = qualify(name)
-        ctx.resource :aws_route53_record, fqdn.gsub(/\./, "-"), {
+        ctx.resource :aws_route53_record, tf_safe(fqdn), {
                    zone_id: @id,
                    name: fqdn,
                    type: "A",
@@ -91,7 +91,7 @@ module Terrafying
 
       def add_alias_in(ctx, name, config)
         fqdn = qualify(name)
-        ctx.resource :aws_route53_record, fqdn.gsub(/\./, "-"), {
+        ctx.resource :aws_route53_record, tf_safe(fqdn), {
                    zone_id: @id,
                    name: fqdn,
                    type: "A",
@@ -101,7 +101,7 @@ module Terrafying
 
       def add_srv(name, service_name, port, type, hosts)
         fqdn = qualify(name)
-        ident = fqdn.gsub(/\./, "-")
+        ident = tf_safe(fqdn)
 
         resource :aws_route53_record, "srv-#{ident}-#{service_name}", {
                    zone_id: @id,

--- a/lib/terrafying/generator.rb
+++ b/lib/terrafying/generator.rb
@@ -95,6 +95,10 @@ module Terrafying
       c[0]
     end
 
+    def tf_safe(str)
+      str.gsub(/[\.\s\/\?]/, "-")
+    end
+
   end
 
   class DSLContext < Context


### PR DESCRIPTION
Terraform resource names have a limitted set of characters that can
appear. This drops some common characters that are not allowed