### PR TITLE
Allow region to be varied

### DIFF
--- a/lib/terrafying/dynamodb.rb
+++ b/lib/terrafying/dynamodb.rb
@@ -23,7 +23,7 @@ module Terrafying
   module DynamoDb
     def self.client
       @@client ||= ::Aws::DynamoDB::Client.new({
-        region: 'eu-west-1',
+        region: Terrafying::Context::REGION,
         #endpoint: 'http://localhost:8000',
       })
     end

--- a/lib/terrafying/generator.rb
+++ b/lib/terrafying/generator.rb
@@ -9,8 +9,10 @@ module Terrafying
 
   class Context
 
+    REGION = ENV.fetch("AWS_REGION", "eu-west-1")
+
     PROVIDER_DEFAULTS = {
-      aws: { region: 'eu-west-1' }
+      aws: { region: REGION }
     }
 
     attr_reader :output
@@ -24,7 +26,7 @@ module Terrafying
     end
 
     def aws
-      @@aws ||= Terrafying::Aws::Ops.new "eu-west-1"
+      @@aws ||= Terrafying::Aws::Ops.new REGION
     end
 
     def provider(name, spec)


### PR DESCRIPTION
People might run this who aren't trying to provision infrastructure
in eu-west-1

The allows the overriding of the default region by specifying an `AWS_REGION` environment variable.

See #59 