### PR TITLE
output_of returns a ref that allows manipulation

### DIFF
--- a/lib/terrafying/generator.rb
+++ b/lib/terrafying/generator.rb
@@ -7,6 +7,26 @@ require 'terrafying/aws'
 
 module Terrafying
 
+  class Ref
+
+    def initialize(var)
+      @var = var
+    end
+
+    def downcase
+      Ref.new("lower(#{@var})")
+    end
+
+    def strip
+      Ref.new("trimspace(#{@var})")
+    end
+
+    def to_s
+      "${#{@var}}"
+    end
+
+  end
+
   class Context
 
     REGION = ENV.fetch("AWS_REGION", "eu-west-1")
@@ -59,11 +79,11 @@ module Terrafying
     end
 
     def id_of(type,name)
-      "${#{type}.#{name}.id}"
+      output_of(type, name, "id")
     end
 
     def output_of(type, name, value)
-      "${#{type}.#{name}.#{value}}"
+      Ref.new("#{type}.#{name}.#{value}")
     end
 
     def pretty_generate

--- a/lib/terrafying/version.rb
+++ b/lib/terrafying/version.rb
@@ -1,4 +1,4 @@
 module Terrafying
-  VERSION = "1.2.3"
+  VERSION = "1.3.0"
   CLI_VERSION = "0.11.2"
 end

--- a/spec/terrafying/generator_spec.rb
+++ b/spec/terrafying/generator_spec.rb
@@ -1,0 +1,62 @@
+
+require 'terrafying/generator'
+
+RSpec.describe Terrafying::Ref do
+
+  context "to_s" do
+    it "should return an interpolated string" do
+      ref = Terrafying::Ref.new("var.thingy")
+
+      expect(ref.to_s).to eq("${var.thingy}")
+    end
+  end
+
+  context "downcase" do
+    it "should wrap it in lower" do
+      ref = Terrafying::Ref.new("var.thingy")
+
+      expect(ref.downcase.to_s).to eq("${lower(var.thingy)}")
+    end
+  end
+
+  context "strip" do
+    it "should wrap it in trimspace" do
+      ref = Terrafying::Ref.new("var.thingy")
+
+      expect(ref.strip.to_s).to eq("${trimspace(var.thingy)}")
+    end
+  end
+
+  it "should stack functions" do
+    ref = Terrafying::Ref.new("var.thingy")
+
+    expect(ref.downcase.strip.to_s).to eq("${trimspace(lower(var.thingy))}")
+  end
+
+end
+
+RSpec.describe Terrafying::Context do
+
+  context "output_of" do
+
+    it "should use a ref" do
+      context = Terrafying::Context.new
+
+      ref = context.output_of(:aws_security_group, "foo", "bar").downcase
+
+      expect("#{ref}").to eq("${lower(aws_security_group.foo.bar)}")
+    end
+
+  end
+
+  context "id_of" do
+    it "should use a ref" do
+      context = Terrafying::Context.new
+
+      ref = context.id_of(:aws_security_group, "foo").downcase
+
+      expect("#{ref}").to eq("${lower(aws_security_group.foo.id)}")
+    end
+  end
+
+end


### PR DESCRIPTION
Datadog lowercases the asg name when it imports metrics, so when
we are configuring the dashboards we need to make sure we lowercase
the asg name too. This lets us do that