### PR TITLE
Add validate method

### DIFF
--- a/lib/terrafying.rb
+++ b/lib/terrafying.rb
@@ -57,6 +57,16 @@ module Terrafying
       exit_code
     end
 
+    def validate
+      exit_code = 1
+      with_config do
+        with_state(mode: :read) do
+          exit_code = exec_with_optional_target 'validate'
+        end
+      end
+      exit_code
+    end
+
     def apply
       exit_code = 1
       with_config do

--- a/lib/terrafying/cli.rb
+++ b/lib/terrafying/cli.rb
@@ -26,6 +26,11 @@ module Terrafying
       exit Config.new(path, options).graph
     end
 
+    desc "validate PATH", "Validate the generated Terraform"
+    def validate(path)
+      exit Config.new(path, options).validate
+    end
+
     desc "apply PATH", "Apply changes to resources"
     option :force, :aliases => ['f'], :type => :boolean, :desc => "Forcefully remove any pending locks"
     def apply(path)


### PR DESCRIPTION
In general the `plan` method is preferable but in cases where we don't
want to call that on un-checked code (e.g. where passwords might be
leaked) `validate` provides a basic check that the generated terraform
is free from basic errors.