### PR TITLE
Add an option to set terraform's state lock timeout

### DIFF
--- a/lib/terrafying.rb
+++ b/lib/terrafying.rb
@@ -129,17 +129,20 @@ module Terrafying
     end
 
     private
-    def targets(options)
-      @options[:target].split(",").map {|target| "-target=#{target}"}.join(" ")
+    def lock_timeout
+      "-lock-timeout=#{@options[:lock_timeout]}" if @options[:lock_timeout]
     end
 
-    def exec_with_optional_target(command)
-      cmd = if @options[:target]
-        "terraform #{command} #{targets(@options)}"
-      else
-        "terraform #{command}"
-      end
-      stream_command(cmd)
+    def targets
+      @options[:target].split(',').map { |target| "-target=#{target}" }.join(' ') if @options[:target]
+    end
+
+    def exec_with_optional_target(command, *args)
+      exec_with_args(command, targets, lock_timeout, *args)
+    end
+
+    def exec_with_args(command, *args)
+      stream_command("terraform #{command} #{args.join(' ')}")
     end
 
     def with_config(&block)

--- a/lib/terrafying/cli.rb
+++ b/lib/terrafying/cli.rb
@@ -2,6 +2,7 @@ require 'thor'
 
 module Terrafying
   class Cli < Thor
+    class_option :lock_timeout, :type => :string, :default => nil
     class_option :no_lock, :type => :boolean, :default => false
     class_option :keep, :type => :boolean, :default => false
     class_option :target, :type => :string, :default => nil


### PR DESCRIPTION
Adds the ability to use `--lock-timeout=XXs` which will be passed to terraform. 

Since we now rely on terraform for state locking this causes lots of erros with state lock contention on the builds. This flag will allow us to configure a build to wait a specified time before failing.