### PR TITLE
Remove bundler bootstrap in terrafying

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,5 @@ RUN apk add --update --no-cache --virtual .terra-builddeps build-base ruby-dev \
 
 WORKDIR /terra
 
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/bin/terrafying
+++ b/bin/terrafying
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-require 'bundler/setup'
 require 'terrafying'
 
 Terrafying::Cli.start(ARGV)


### PR DESCRIPTION
We're installing it as a system gem inside the container so we don't need bundler there. If an app uses terrafying it can easily include it and be run it with bundle exec.

Also unsetting the ruby image's IRB entrypoint in favour of the regular sh -c as this has been causing errors since the switch from `terrafying plan`. Might be a better way to tackle this in the future but unneeded at present.