### PR TITLE
Don't pretty generate json for instances

### DIFF
--- a/lib/terrafying/util.rb
+++ b/lib/terrafying/util.rb
@@ -24,7 +24,7 @@ module Terrafying
         }
       end
 
-      JSON.pretty_generate(config)
+      JSON.generate(config)
     end
 
   end


### PR DESCRIPTION
This removes whitespace from the final user data saving a couple of hunderd to thousand bytes