### PR TITLE
Don't return private zones when finding a zone by fqdn as we get duplicates

### DIFF
--- a/lib/terrafying/aws.rb
+++ b/lib/terrafying/aws.rb
@@ -352,7 +352,7 @@ module Terrafying
           begin
             STDERR.puts "looking for a hosted zone with fqdn '#{fqdn}'"
             hosted_zones = @route53_client.list_hosted_zones_by_name({ dns_name: fqdn }).hosted_zones.select { |zone|
-              zone.name == "#{fqdn}."
+              zone.name == "#{fqdn}." && !zone.config.private_zone
             }
             case
             when hosted_zones.count == 1


### PR DESCRIPTION
We'll need to look at implementing a find for private zones in the future as VPC info doesn't get returned from the list call and could become quite expensive to lookup.