### PR TITLE
Allow overriding of the default providers

### DIFF
--- a/spec/terrafying/generator_spec.rb
+++ b/spec/terrafying/generator_spec.rb
@@ -319,8 +319,21 @@ RSpec.describe Terrafying::Context do
 end
 
 RSpec.describe Terrafying::RootContext do
-  context('initialise') do
-    it 'should add the default aws provider' do
+
+  context "default providers" do
+    it "should let you override default providers" do
+      context = Terrafying::RootContext.new
+
+      context.provider("aws", { region: "wibble-1" })
+
+      providers = context.output_with_children['provider']
+
+      expect(providers).to include(
+        a_hash_including('aws' => { region: 'wibble-1' })
+      )
+    end
+
+    it "should add default ones" do
       context = Terrafying::RootContext.new
 
       providers = context.output_with_children['provider']


### PR DESCRIPTION
In order to pin versions of the AWS provider we need to be able to
define the provider rather than it being defaulted. This maintains
backwards compatibility by defaulting the providers if not already
stated