### PR TITLE
Drop * when creating a terraform safe string

### DIFF
--- a/lib/terrafying/generator.rb
+++ b/lib/terrafying/generator.rb
@@ -292,7 +292,7 @@ module Terrafying
     end
 
     def tf_safe(str)
-      str.gsub(%r{[\.\s/\?]}, '-')
+      str.gsub(%r{[\.\s/\?]}, '-').gsub(%r{\*}, "star")
     end
   end
 


### PR DESCRIPTION
It doesn't like it and it has cropped up with wildcard domain names