### PR TITLE
Add support for modules to Terrafying

### DIFF
--- a/lib/terrafying/generator.rb
+++ b/lib/terrafying/generator.rb
@@ -240,6 +240,16 @@ module Terrafying
       RootRef.new(kind: :resource, type: type, name: name)
     end
 
+    def tf_module(name, spec)
+      @output['module'] ||= {}
+
+      raise "Module already exists #{name}" if @output['module'].key? name.to_s
+
+      @output['module'][name.to_s] = spec
+
+      RootRef.new(kind: :module, name: name)
+    end
+
     def template(relative_path, params = {})
       dir = caller_locations[0].path
       filename = File.join(File.dirname(dir), relative_path)
@@ -341,6 +351,7 @@ module Terrafying
       provider
       resource
       data
+      tf_module
       template
       tf_safe
       id_of

--- a/spec/terrafying/generator_spec.rb
+++ b/spec/terrafying/generator_spec.rb
@@ -92,6 +92,12 @@ RSpec.describe Terrafying::Ref do
     expect(r_thing_id.to_s).to eq('${aws_wibble.foo.thing.id}')
   end
 
+  it 'lets us look up an output' do
+    r = Terrafying::RootRef.new(kind: :module, name: 'wibble')
+    r_thing = r['thing']
+    expect(r_thing.to_s).to eq('${module.wibble.thing}')
+  end
+
   it 'lets us look up a var when called fn' do
     r = Terrafying::RootRef.new(kind: :resource, type: 'aws_wibble', name: 'foo')
     r_lower = r.downcase
@@ -273,6 +279,15 @@ RSpec.describe Terrafying::Context do
     expect do
       context.data(:aws_instance, 'wibble', {})
     end.to raise_error(/aws_instance.wibble/)
+  end
+
+  it 'should reject duplicate module' do
+    context = Terrafying::Context.new
+
+    context.tf_module(:wibble, {})
+    expect do
+      context.tf_module(:wibble, {})
+    end.to raise_error(/wibble/)
   end
 
   context 'output_of' do


### PR DESCRIPTION
This is the test case;
```
Terrafying::Generator.generate do
  role = tf_module 'role', 
    source: './role',
    providers: {
      aws: "aws"
    },
    created_by: 'wai'

  policy = tf_module('policy', source: './policy', policy_name: 'test_policy')

  resource :aws_iam_role_policy_attachment, "attach_role",
    role: role['name'],
    policy_arn: policy['policy_arn']

end
```

`policy_arn` and `name` were outputs of the module