### PR TITLE
Make sure that resource name doesn't start with numbers.

### DIFF
--- a/lib/terrafying/generator.rb
+++ b/lib/terrafying/generator.rb
@@ -302,7 +302,7 @@ module Terrafying
     end
 
     def tf_safe(str)
-      str.gsub(%r{[\.\s/\?]}, '-').gsub(%r{\*}, "star")
+      str.gsub(%r{[\.\s/\?]}, '-').gsub(%r{\*}, "star").gsub(%r{^(\d)}, '_\1')
     end
   end
 


### PR DESCRIPTION
In Terraform v12, `A name must start with a letter or underscore and may contain only letters,
digits, underscores, and dashes`. 

This syntax is also acceptable in v11 so won't break anything. But as some resources change, this would require moving of resources to their new names. `terraform mv old_resource_name new_resource_name`

Is it better to do it here or within the individual repos?