### PR TITLE
bump terraform version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.6.3-alpine3.9
 
 ARG TERRAFYING_VERSION=0.0.0
 
-RUN wget -O terraform.zip https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip \
+RUN wget -O terraform.zip https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_amd64.zip \
  && unzip terraform.zip \
  && install -m 755 terraform /usr/bin/terraform \
  && install -d ${HOME}/.terraform.d/plugins/linux_amd64 \


### PR DESCRIPTION
Context: https://discuss.hashicorp.com/t/terraform-updates-for-hcsec-2021-12/23570

`0.11.0 - 0.11.14	| Y	| Terraform should function as it did previously; however, you should update to get the new GPG key before upgrading any providers.	| Upgrade to 0.11.15.`