### PR TITLE
Add ability to add required_providers and required_version

### DIFF
--- a/lib/terrafying/generator.rb
+++ b/lib/terrafying/generator.rb
@@ -199,6 +199,18 @@ module Terrafying
       [name, spec[:alias]].compact.join('.')
     end
 
+    def required_provider(name, spec)
+      @output['terraform'] ||= {}
+      @output['terraform']['required_providers'] ||= {}
+      return if @output['terraform']['required_providers'].key? name.to_s
+
+      @output['terraform']['required_providers'][name.to_s] = spec
+    end
+
+    def required_version(version)
+      @output['terraform']['required_version'] = ">= #{version}"
+    end
+
     def key_exists_spec_differs(key, name, spec)
       @providers.key?(key) && spec != @providers[key][name.to_s]
     end

--- a/lib/terrafying/generator.rb
+++ b/lib/terrafying/generator.rb
@@ -202,13 +202,16 @@ module Terrafying
     def required_provider(name, spec)
       @output['terraform'] ||= {}
       @output['terraform']['required_providers'] ||= {}
-      return if @output['terraform']['required_providers'].key? name.to_s
+      raise "Duplicate required_provider configuration detected for #{name}" if @output['terraform']['required_providers'].key? name.to_s
 
       @output['terraform']['required_providers'][name.to_s] = spec
     end
 
     def required_version(version)
-      @output['terraform']['required_version'] = ">= #{version}"
+      @output['terraform'] ||= {}
+      raise "required_version already configure" if @output['terraform']['required_version']
+
+      @output['terraform']['required_version'] = "#{version}"
     end
 
     def key_exists_spec_differs(key, name, spec)


### PR DESCRIPTION
Adds the ability to add required_providers and required_versions inside `terraform` block.

This is necessary to enable upgrading to TF 0.13

Works as;
```ruby
Terrafying::Generator.generate do
  required_provider('aws', {"source" => "hashicorp/aws", "version" =>  "~> 3.42.0"})
  required_provider('acme', {"source" => "vancluever/acme", "version" =>  "~> 2.4.0"})
  required_version(">= 0.13")
end
```
As well as;
```ruby
Terrafying::Generator.required_provider('aws', {"source" => "hashicorp/aws", "version" =>  "~> 3.42.0"})
Terrafying::Generator.required_provider('acme', {"source" => "vancluever/acme", "version" =>  "~> 2.4.0"})
Terrafying::Generator.required_version(">= 0.13")
```

Here for reference: https://www.notion.so/rvu/Migrating-a-Terrafying-repo-from-Terraform-v0-12-to-Terraform-v0-13-df7ab5d7d8134e6d9f622ba26be7743d#915079efd4be4dc89944d504b634fe8f